### PR TITLE
Previous change broke browsers with existing flash cookies

### DIFF
--- a/src/com/googlecode/utterlyidle/flash/FlashHandler.java
+++ b/src/com/googlecode/utterlyidle/flash/FlashHandler.java
@@ -10,6 +10,7 @@ import com.googlecode.utterlyidle.cookies.CookieParameters;
 
 import static com.googlecode.funclate.json.Json.toJson;
 import static com.googlecode.totallylazy.Pair.pair;
+import static com.googlecode.totallylazy.Strings.isBlank;
 import static com.googlecode.utterlyidle.Requests.cookies;
 import static com.googlecode.utterlyidle.ResponseBuilder.modify;
 import static com.googlecode.utterlyidle.cookies.CookieAttribute.path;
@@ -53,7 +54,7 @@ public class FlashHandler implements HttpHandler {
 	private static void setIncomingFlashValues(Request request, Flash flash) {
 		CookieParameters requestCookies = cookies(request);
 
-		if(!requestCookies.contains(FLASH_COOKIE) || isEmptyJson(requestCookies.getValue(FLASH_COOKIE))) return;
+		if(!requestCookies.contains(FLASH_COOKIE) || isEmptyJson(requestCookies.getValue(FLASH_COOKIE)) || isBlank(requestCookies.getValue(FLASH_COOKIE))) return;
 
 		flash.merge(Model.persistent.parse(requestCookies.getValue(FLASH_COOKIE)));
 	}

--- a/test/com/googlecode/utterlyidle/flash/FlashHandlerTest.java
+++ b/test/com/googlecode/utterlyidle/flash/FlashHandlerTest.java
@@ -27,6 +27,7 @@ import static com.googlecode.utterlyidle.MediaType.TEXT_PLAIN;
 import static com.googlecode.utterlyidle.RequestBuilder.get;
 import static com.googlecode.utterlyidle.RequestBuilder.post;
 import static com.googlecode.utterlyidle.ResponseBuilder.response;
+import static com.googlecode.utterlyidle.Status.OK;
 import static com.googlecode.utterlyidle.annotations.AnnotatedBindings.annotatedClass;
 import static com.googlecode.utterlyidle.cookies.CookieParameters.cookies;
 import static com.googlecode.utterlyidle.flash.FlashHandler.FLASH_COOKIE;
@@ -89,14 +90,23 @@ public class FlashHandlerTest {
 
 	@Test
 	public void onlySetCookieIfValueChanges() throws Exception {
-		Response response = application.handle(withFlashCookie(CLEARED_FLASH_COOKIE_VALUE, post("/hi")).build());
+		Response response = application.handle(withFlashCookie(CLEARED_FLASH_COOKIE_VALUE, get("/hi")).build());
+		assertThat(response.status(), is(OK));
 		assertThat(cookies(response).contains(FLASH_COOKIE), is(false));
 	}
 
 	@Test
 	public void thereIsNoNeedToSetTheFlashCookieIfItsValueIsEmptyJsonAndTheIncomingRequestHasNoFlashCookie () throws Exception {
-		Response response = application.handle(post("/hi").build());
+		Response response = application.handle(get("/hi").build());
+		assertThat(response.status(), is(OK));
 		assertThat(cookies(response).contains(FLASH_COOKIE), is(false));
+	}
+
+	@Test
+	public void migratesPreviousEmptyCookieValueToNewEmptyCookieValue () throws Exception {
+		Response response = application.handle(withFlashCookie("", get("/hi")).build());
+		assertThat(response.status(), is(OK));
+		assertThat(cookies(response).getValue(FLASH_COOKIE), is(CLEARED_FLASH_COOKIE_VALUE));
 	}
 
 	private Response followRedirect(Response response) throws Exception {


### PR DESCRIPTION
The previous change modified the empty flash cookie value from "" to "{}".  Using this valid empty json simplified the code in my mind.

But, browsers might have the previous old empty flash cookie value of "", which is not valid json and causes a json parse exception.  so i needed to add a case to migrate browsers with this empty flash cookie value to a new value of "{}".