### PR TITLE
Malformed cookies with no '=' no longer result in a StringIndexOutOfBoundsException

### DIFF
--- a/src/com/googlecode/utterlyidle/cookies/CookieParameters.java
+++ b/src/com/googlecode/utterlyidle/cookies/CookieParameters.java
@@ -74,9 +74,19 @@ public class CookieParameters extends Parameters<String, String, CookieParameter
     public static Sequence<Pair<String, String>> cookies(String header) {
         return regex("\\s*;\\s*").
                 split(header).
+                filter(correctlyFormed()).
                 map(splitOnFirst("=")).
                 filter(not(anAttribute())).
                 map(Callables.<String, String, String>second(Rfc2616.toUnquotedString()));
+    }
+
+    private static Predicate<? super String> correctlyFormed() {
+        return new Predicate<String>() {
+            @Override
+            public boolean matches(final String cookie) {
+                return cookie.contains("=");
+            }
+        };
     }
 
     private static Predicate<? super Pair<String, String>> anAttribute() {

--- a/test/com/googlecode/utterlyidle/cookies/CookieParametersTest.java
+++ b/test/com/googlecode/utterlyidle/cookies/CookieParametersTest.java
@@ -65,6 +65,15 @@ public class CookieParametersTest extends ParametersContract<CookieParameters> {
     }
 
     @Test
+    public void willIgnoreMalformedCookies() throws Exception {
+        CookieParameters cookies = cookies(request(headerParameters(one(pair("Cookie", "invalidCookie; a=1")))).headers());
+
+        assertThat(cookies.getValue("invalidCookie"), is(nullValue()));
+
+        assertThat(cookies.getValue("a"), is("1"));
+    }
+
+    @Test
     public void copesWithCookieHeaderWithNoCookies() {
         CookieParameters cookies = cookies(request(headerParameters(one(pair("Cookie", "")))).headers());
         assertThat(cookies.size(), is(0));


### PR DESCRIPTION
We're getting scripted attacks on our live servers that include malformed cookies without '=' symbols. This currently causes a StringIndexOutOfBoundsExceptions during the split of the cookies.

This patch adds a filter to ensure only values containing a '=' symbol are parsed.