### PR TITLE
Fix for issue with merging of resource class and method path annotations

### DIFF
--- a/src/com/googlecode/utterlyidle/annotations/UriTemplateExtractor.java
+++ b/src/com/googlecode/utterlyidle/annotations/UriTemplateExtractor.java
@@ -9,6 +9,7 @@ import java.lang.reflect.Method;
 
 import static com.googlecode.totallylazy.Predicates.notNullValue;
 import static com.googlecode.totallylazy.Sequences.sequence;
+import static com.googlecode.utterlyidle.UriTemplate.trimSlashes;
 
 public class UriTemplateExtractor implements Extractor<Method, UriTemplate> {
     static UriTemplate uriTemplate(Method method) {
@@ -23,7 +24,7 @@ public class UriTemplateExtractor implements Extractor<Method, UriTemplate> {
     public static Callable1<? super Path, String> getValue() {
         return new Callable1<Path, String>() {
             public String call(Path o) throws Exception {
-                return o.value();
+                return trimSlashes(o.value());
             }
         };
     }

--- a/test/com/googlecode/utterlyidle/annotations/UriTemplateExtractorTest.java
+++ b/test/com/googlecode/utterlyidle/annotations/UriTemplateExtractorTest.java
@@ -1,0 +1,26 @@
+package com.googlecode.utterlyidle.annotations;
+
+import com.googlecode.utterlyidle.UriTemplate;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+
+import static com.googlecode.utterlyidle.annotations.UriTemplateExtractor.uriTemplate;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class UriTemplateExtractorTest {
+    @Test
+    public void mergesClassAndMethodPathAnnotations() {
+        @Path("/test")
+        class TestResource {
+            @GET
+            @Path("/method")
+            public Method method() {
+                return new Object() {}.getClass().getEnclosingMethod();
+            }
+        }
+
+        assertThat(uriTemplate(new TestResource().method()), is(UriTemplate.uriTemplate("test/method")));
+    }
+}


### PR DESCRIPTION
Fixed issue where if a resource had both a class path annotation and a method path annotation beginning with '/', then the 'UriTemplateExtractor' would merge the paths with '//' in the middle.