### PR TITLE
Add support for encoded cookies.

### DIFF
--- a/src/com/googlecode/utterlyidle/RequestBuilder.java
+++ b/src/com/googlecode/utterlyidle/RequestBuilder.java
@@ -239,6 +239,10 @@ public class RequestBuilder implements Callable<Request> {
         return header(HttpHeaders.CONTENT_TYPE, contentType);
     }
 
+    public RequestBuilder replaceCookie(Cookie cookie) {
+        return replaceCookie(cookie.name(), cookie.value());
+    }
+
     public RequestBuilder replaceCookie(final String name, final String value) {
         return mapCookies(setCookie(name, value));
     }

--- a/src/com/googlecode/utterlyidle/ResponseBuilder.java
+++ b/src/com/googlecode/utterlyidle/ResponseBuilder.java
@@ -1,9 +1,12 @@
 package com.googlecode.utterlyidle;
 
+import com.googlecode.totallylazy.Callables;
 import com.googlecode.totallylazy.First;
+import com.googlecode.totallylazy.Function1;
 import com.googlecode.totallylazy.Pair;
 import com.googlecode.totallylazy.Predicate;
 import com.googlecode.totallylazy.Second;
+import com.googlecode.totallylazy.Sequence;
 import com.googlecode.totallylazy.Sequences;
 import com.googlecode.totallylazy.predicates.LogicalPredicate;
 import com.googlecode.totallylazy.time.Dates;
@@ -14,17 +17,24 @@ import java.util.Date;
 import java.util.List;
 
 import static com.googlecode.totallylazy.Callables.first;
+import static com.googlecode.totallylazy.Callables.replace;
 import static com.googlecode.totallylazy.Callables.second;
+import static com.googlecode.totallylazy.Functions.returns1;
 import static com.googlecode.totallylazy.Pair.pair;
 import static com.googlecode.totallylazy.Predicates.and;
 import static com.googlecode.totallylazy.Predicates.is;
 import static com.googlecode.totallylazy.Predicates.not;
 import static com.googlecode.totallylazy.Predicates.where;
 import static com.googlecode.totallylazy.Sequences.sequence;
+import static com.googlecode.totallylazy.Strings.blank;
+import static com.googlecode.totallylazy.Strings.equalIgnoringCase;
 import static com.googlecode.totallylazy.Strings.startsWith;
+import static com.googlecode.utterlyidle.HttpHeaders.COOKIE;
 import static com.googlecode.utterlyidle.cookies.CookieAttribute.expires;
 import static com.googlecode.utterlyidle.cookies.CookieAttribute.maxAge;
+import static com.googlecode.utterlyidle.cookies.CookieParameters.cookies;
 import static com.googlecode.utterlyidle.cookies.CookieParameters.toHttpHeader;
+import static java.lang.String.format;
 
 public class ResponseBuilder {
     private Status status;
@@ -68,6 +78,10 @@ public class ResponseBuilder {
     public ResponseBuilder removeCookie(String name) {
         return removeHeaders(HttpHeaders.SET_COOKIE, startsWith(name + "=")).
             cookie(Cookie.cookie(name, "", maxAge(0), expires(new Date(0))));
+    }
+
+    public ResponseBuilder replaceCookie(Cookie cookie) {
+        return removeHeaders(HttpHeaders.SET_COOKIE, startsWith(cookie.name() + "=")).cookie(cookie);
     }
 
     public Response build() {

--- a/src/com/googlecode/utterlyidle/cookies/Base64Encoding.java
+++ b/src/com/googlecode/utterlyidle/cookies/Base64Encoding.java
@@ -1,0 +1,16 @@
+package com.googlecode.utterlyidle.cookies;
+
+import com.googlecode.totallylazy.security.Base64;
+
+public class Base64Encoding implements CookieEncoding {
+
+    @Override
+    public String encode(String input) {
+        return Base64.encode(input.getBytes());
+    }
+
+    @Override
+    public String decode(String input) {
+        return new String(Base64.decode(input));
+    }
+}

--- a/src/com/googlecode/utterlyidle/cookies/Cookie.java
+++ b/src/com/googlecode/utterlyidle/cookies/Cookie.java
@@ -1,6 +1,7 @@
 package com.googlecode.utterlyidle.cookies;
 
 import com.googlecode.totallylazy.Sequence;
+import com.googlecode.utterlyidle.Request;
 import com.googlecode.utterlyidle.Rfc2616;
 
 import static com.googlecode.totallylazy.Sequences.sequence;
@@ -37,7 +38,16 @@ public class Cookie {
     public String toString() {
         final String cookieValue = format("%s=%s; ", name, Rfc2616.toQuotedString(value));
         final String attributes = this.attributes.toString("; ");
-
         return cookieValue + attributes;
+    }
+
+    @Override
+    public int hashCode() {
+        return toString().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof Cookie && other.toString().equals(toString());
     }
 }

--- a/src/com/googlecode/utterlyidle/cookies/CookieAttribute.java
+++ b/src/com/googlecode/utterlyidle/cookies/CookieAttribute.java
@@ -1,5 +1,7 @@
 package com.googlecode.utterlyidle.cookies;
 
+import com.googlecode.utterlyidle.Request;
+
 import java.util.Date;
 
 import static com.googlecode.totallylazy.time.Dates.RFC822;
@@ -73,5 +75,15 @@ public class CookieAttribute {
     @Override
     public String toString() {
         return String.format("%s=%s", name, value);
+    }
+
+    @Override
+    public int hashCode() {
+        return toString().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof CookieAttribute && other.toString().equals(toString());
     }
 }

--- a/src/com/googlecode/utterlyidle/cookies/CookieBuilder.java
+++ b/src/com/googlecode/utterlyidle/cookies/CookieBuilder.java
@@ -1,0 +1,55 @@
+package com.googlecode.utterlyidle.cookies;
+
+import com.googlecode.totallylazy.Callable2;
+import com.googlecode.totallylazy.Sequence;
+
+import java.util.concurrent.Callable;
+
+import static com.googlecode.totallylazy.Sequences.sequence;
+
+public class CookieBuilder implements Callable<Cookie> {
+
+    public static CookieBuilder modify(Cookie cookie) {
+        return new CookieBuilder(cookie);
+    }
+
+    private String name;
+    private String value;
+    private Sequence<CookieAttribute> attributes = sequence();
+
+    private CookieBuilder(Cookie cookie) {
+        this.name = cookie.name();
+        this.value = cookie.value();
+
+        sequence(cookie.attributes()).fold(this, new Callable2<CookieBuilder, CookieAttribute, CookieBuilder>() {
+            @Override
+            public CookieBuilder call(CookieBuilder cookieBuilder, CookieAttribute cookieAttribute) throws Exception {
+                return cookieBuilder.attribute(cookieAttribute);
+            }
+        });
+    }
+
+    public CookieBuilder name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public CookieBuilder value(String value) {
+        this.value = value;
+        return this;
+    }
+
+    public CookieBuilder attribute(CookieAttribute attribute) {
+        this.attributes = this.attributes.append(attribute);
+        return this;
+    }
+
+    @Override
+    public Cookie call() throws Exception {
+        return build();
+    }
+
+    public Cookie build() {
+        return Cookie.cookie(name, value, attributes.toArray(new CookieAttribute[attributes.size()]));
+    }
+}

--- a/src/com/googlecode/utterlyidle/cookies/CookieCutter.java
+++ b/src/com/googlecode/utterlyidle/cookies/CookieCutter.java
@@ -1,0 +1,100 @@
+package com.googlecode.utterlyidle.cookies;
+
+import com.googlecode.totallylazy.Callables;
+import com.googlecode.totallylazy.Function1;
+import com.googlecode.totallylazy.Option;
+import com.googlecode.totallylazy.Pair;
+import com.googlecode.totallylazy.Predicate;
+import com.googlecode.totallylazy.Sequence;
+import com.googlecode.utterlyidle.Request;
+import com.googlecode.utterlyidle.Response;
+import com.googlecode.utterlyidle.Rfc2616;
+
+import static com.googlecode.totallylazy.Option.none;
+import static com.googlecode.totallylazy.Option.some;
+import static com.googlecode.totallylazy.Pair.pair;
+import static com.googlecode.totallylazy.Sequences.flatten;
+import static com.googlecode.totallylazy.regex.Regex.regex;
+import static com.googlecode.utterlyidle.HttpHeaders.COOKIE;
+import static com.googlecode.utterlyidle.HttpHeaders.SET_COOKIE;
+import static com.googlecode.utterlyidle.cookies.Cookie.cookie;
+import static com.googlecode.utterlyidle.cookies.CookieAttribute.cookieAttribute;
+
+public class CookieCutter {
+
+    public static Iterable<Cookie> cookies(Request request) {
+        return request.headers().getValues(COOKIE).flatMap(parseCookieHeader());
+    }
+
+    public static Iterable<Cookie> cookies(Response response) {
+        return flatten(response.headers().getValues(SET_COOKIE).map(parseSetCookieHeader()));
+    }
+
+    private static Function1<String, Iterable<Cookie>> parseCookieHeader() {
+        return new Function1<String, Iterable<Cookie>>() {
+            @Override
+            public Iterable<Cookie> call(String header) throws Exception {
+                return parseNameValuePairs(header).map(buildCookie());
+            }
+        };
+    }
+
+    private static Function1<String, Option<Cookie>> parseSetCookieHeader() {
+        return new Function1<String, Option<Cookie>>() {
+            @Override
+            public Option<Cookie> call(String header) throws Exception {
+                return buildCookieWithAttributes(parseNameValuePairs(header));
+            }
+        };
+    }
+
+    private static Function1<Pair<String, String>, Cookie> buildCookie() {
+        return new Function1<Pair<String, String>, Cookie>() {
+            @Override
+            public Cookie call(final Pair<String, String> header) throws Exception {
+                return cookie(header.first(), header.second());
+            }
+        };
+    }
+
+    private static Option<Cookie> buildCookieWithAttributes(Sequence<Pair<String, String>> pairs) {
+        if(pairs.isEmpty()) {
+            return none();
+        } else {
+            return some(cookie(pairs.head().first(), pairs.head().second(), attributes(pairs.tail()).toArray(new CookieAttribute[pairs.tail().size()])));
+        }
+    }
+
+    private static Sequence<CookieAttribute> attributes(Sequence<Pair<String, String>> attributes) {
+        return attributes.map(new Function1<Pair<String, String>, CookieAttribute>() {
+            @Override
+            public CookieAttribute call(final Pair<String, String> pair) throws Exception {
+                return cookieAttribute(pair.first(), pair.second());
+            }
+        });
+    }
+
+    private static Sequence<Pair<String, String>> parseNameValuePairs(final String header) {
+        return regex("\\s*;\\s*").split(header)
+                .filter(correctlyFormed())
+                .map(splitOnFirst("="))
+                .map(Callables.<String, String, String>second(Rfc2616.toUnquotedString()));
+    }
+
+    private static Predicate<? super String> correctlyFormed() {
+        return new Predicate<String>() {
+            @Override
+            public boolean matches(final String cookie) {
+                return cookie.contains("=");
+            }
+        };
+    }
+
+    private static Function1<? super String, Pair<String, String>> splitOnFirst(final String separator) {
+        return new Function1<String, Pair<String, String>>() {
+            public Pair<String, String> call(String cookie) throws Exception {
+                return pair(cookie.substring(0, cookie.indexOf(separator)), cookie.substring(cookie.indexOf(separator) + 1, cookie.length()));
+            }
+        };
+    }
+}

--- a/src/com/googlecode/utterlyidle/cookies/CookieEncoder.java
+++ b/src/com/googlecode/utterlyidle/cookies/CookieEncoder.java
@@ -1,0 +1,50 @@
+package com.googlecode.utterlyidle.cookies;
+
+import com.googlecode.totallylazy.Callable2;
+import com.googlecode.utterlyidle.HttpHandler;
+import com.googlecode.utterlyidle.Request;
+import com.googlecode.utterlyidle.RequestBuilder;
+import com.googlecode.utterlyidle.Response;
+import com.googlecode.utterlyidle.ResponseBuilder;
+
+import static com.googlecode.totallylazy.Sequences.sequence;
+import static com.googlecode.utterlyidle.cookies.CookieBuilder.modify;
+import static com.googlecode.utterlyidle.cookies.CookieCutter.cookies;
+
+public class CookieEncoder implements HttpHandler {
+
+    private final HttpHandler delegate;
+    private final CookieEncoding encoder;
+
+    public CookieEncoder(HttpHandler delegate, CookieEncoding encoder) {
+        this.delegate = delegate;
+        this.encoder = encoder;
+    }
+
+    @Override
+    public Response handle(Request request) throws Exception {
+        return encode(delegate.handle(decode(request)));
+    }
+
+    private Response encode(Response response) {
+        final ResponseBuilder builder = ResponseBuilder.modify(response);
+        sequence(cookies(response)).fold(builder, new Callable2<ResponseBuilder, Cookie, ResponseBuilder>() {
+            @Override
+            public ResponseBuilder call(ResponseBuilder builder, Cookie cookie) throws Exception {
+                return builder.replaceCookie(modify(cookie).value(encoder.encode(cookie.value())).build());
+            }
+        });
+        return builder.build();
+    }
+
+    private Request decode(Request request) {
+        final RequestBuilder builder = RequestBuilder.modify(request);
+        sequence(cookies(request)).fold(builder, new Callable2<RequestBuilder, Cookie, RequestBuilder>() {
+            @Override
+            public RequestBuilder call(RequestBuilder builder, Cookie cookie) throws Exception {
+                return builder.replaceCookie(modify(cookie).value(encoder.decode(cookie.value())).build());
+            }
+        });
+        return builder.build();
+    }
+}

--- a/src/com/googlecode/utterlyidle/cookies/CookieEncoding.java
+++ b/src/com/googlecode/utterlyidle/cookies/CookieEncoding.java
@@ -1,0 +1,6 @@
+package com.googlecode.utterlyidle.cookies;
+
+public interface CookieEncoding {
+    public String decode(String input);
+    public String encode(String input);
+}

--- a/src/com/googlecode/utterlyidle/cookies/IdentityEncoding.java
+++ b/src/com/googlecode/utterlyidle/cookies/IdentityEncoding.java
@@ -1,0 +1,14 @@
+package com.googlecode.utterlyidle.cookies;
+
+public class IdentityEncoding implements CookieEncoding {
+
+    @Override
+    public String encode(String input) {
+        return input;
+    }
+
+    @Override
+    public String decode(String input) {
+        return input;
+    }
+}

--- a/src/com/googlecode/utterlyidle/cookies/UrlEncoding.java
+++ b/src/com/googlecode/utterlyidle/cookies/UrlEncoding.java
@@ -1,0 +1,29 @@
+package com.googlecode.utterlyidle.cookies;
+
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+
+import static com.googlecode.totallylazy.LazyException.lazyException;
+
+public class UrlEncoding implements CookieEncoding {
+
+    private static final String characterEncoding = "UTF-8";
+
+    @Override
+    public String encode(String input) {
+        try {
+            return URLEncoder.encode(input, characterEncoding);
+        } catch (Exception e) {
+            throw lazyException(e);
+        }
+    }
+
+    @Override
+    public String decode(String input) {
+        try {
+            return URLDecoder.decode(input, characterEncoding);
+        } catch (Exception e) {
+            throw lazyException(e);
+        }
+    }
+}

--- a/test/com/googlecode/utterlyidle/cookies/Base64EncodingTest.java
+++ b/test/com/googlecode/utterlyidle/cookies/Base64EncodingTest.java
@@ -1,0 +1,19 @@
+package com.googlecode.utterlyidle.cookies;
+
+public class Base64EncodingTest extends CookieEncodingContract {
+
+    @Override
+    protected String input() {
+        return "Hōb Nőḃ";
+    }
+
+    @Override
+    protected String expectedOutput() {
+        return "SMWNYiBOxZHhuIM=";
+    }
+
+    @Override
+    protected CookieEncoding encoding() {
+        return new Base64Encoding();
+    }
+}

--- a/test/com/googlecode/utterlyidle/cookies/CookieBuilderTest.java
+++ b/test/com/googlecode/utterlyidle/cookies/CookieBuilderTest.java
@@ -1,0 +1,23 @@
+package com.googlecode.utterlyidle.cookies;
+
+import org.junit.Test;
+
+import static com.googlecode.totallylazy.matchers.Matchers.is;
+import static com.googlecode.utterlyidle.cookies.CookieAttribute.comment;
+import static com.googlecode.utterlyidle.cookies.CookieAttribute.domain;
+import static com.googlecode.utterlyidle.cookies.CookieBuilder.modify;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.*;
+
+public class CookieBuilderTest {
+
+    @Test
+    public void canModifyExistingCookie() throws Exception {
+        Cookie existing = Cookie.cookie("cookie1", "Custard Cream", comment("comment"));
+        Cookie modified = modify(existing).value("Chocolate Hob Nob").attribute(domain("localhost")).build();
+
+        assertThat(modified.name(), is(existing.name()));
+        assertThat(modified.value(), is("Chocolate Hob Nob"));
+        assertThat(modified.attributes(), containsInAnyOrder(comment("comment"), domain("localhost")));
+    }
+}

--- a/test/com/googlecode/utterlyidle/cookies/CookieCutterRequestTest.java
+++ b/test/com/googlecode/utterlyidle/cookies/CookieCutterRequestTest.java
@@ -1,0 +1,49 @@
+package com.googlecode.utterlyidle.cookies;
+
+import com.googlecode.utterlyidle.Request;
+import com.googlecode.utterlyidle.RequestBuilder;
+import org.junit.Test;
+
+import static com.googlecode.utterlyidle.HttpHeaders.COOKIE;
+import static com.googlecode.utterlyidle.RequestBuilder.get;
+import static com.googlecode.utterlyidle.cookies.Cookie.cookie;
+import static com.googlecode.utterlyidle.cookies.CookieCutter.cookies;
+import static com.googlecode.utterlyidle.cookies.EmptyCookiesMatcher.isEmpty;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
+
+public class CookieCutterRequestTest {
+
+    private final Cookie cookie1 = cookie("cookie1", "Viscount");
+    private final Cookie cookie2 = cookie("cookie2", "Penguin");
+    private final Cookie cookie3 = cookie("cookie3", "Club");
+
+    @Test
+    public void handlesRequestsWithNoCookies() throws Exception {
+        assertThat(cookies(requestWithoutCookies()), isEmpty());
+    }
+
+    @Test
+    public void extractsCookiesFromRequest() throws Exception {
+        assertThat(cookies(requestWithCookies(cookie1, cookie2, cookie3)), containsInAnyOrder(cookie1, cookie2, cookie3));
+    }
+
+    @Test
+    public void ignoresMalformedCookies() throws Exception {
+        Request request = get("/").header(COOKIE, "hello;" + cookie1).build();
+        assertThat(cookies(request), contains(cookie1));
+    }
+
+    private Request requestWithoutCookies() {
+        return requestWithCookies();
+    }
+
+    private Request requestWithCookies(Cookie... cookies) {
+        RequestBuilder builder = RequestBuilder.get("/");
+        for (Cookie cookie : cookies) {
+            builder.cookie(cookie);
+        }
+        return builder.build();
+    }
+}

--- a/test/com/googlecode/utterlyidle/cookies/CookieCutterResponseTest.java
+++ b/test/com/googlecode/utterlyidle/cookies/CookieCutterResponseTest.java
@@ -1,0 +1,52 @@
+package com.googlecode.utterlyidle.cookies;
+
+import com.googlecode.utterlyidle.Request;
+import com.googlecode.utterlyidle.Response;
+import com.googlecode.utterlyidle.ResponseBuilder;
+import org.junit.Test;
+
+import static com.googlecode.utterlyidle.HttpHeaders.SET_COOKIE;
+import static com.googlecode.utterlyidle.RequestBuilder.get;
+import static com.googlecode.utterlyidle.cookies.Cookie.cookie;
+import static com.googlecode.utterlyidle.cookies.CookieAttribute.comment;
+import static com.googlecode.utterlyidle.cookies.CookieAttribute.httpOnly;
+import static com.googlecode.utterlyidle.cookies.CookieAttribute.secure;
+import static com.googlecode.utterlyidle.cookies.CookieCutter.cookies;
+import static com.googlecode.utterlyidle.cookies.EmptyCookiesMatcher.isEmpty;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
+
+public class CookieCutterResponseTest {
+
+    private final Cookie cookie1 = cookie("cookie1", "Viscount");
+    private final Cookie cookie2 = cookie("cookie2", "Penguin", httpOnly(), secure());
+    private final Cookie cookie3 = cookie("cookie3", "Club", comment("If you like a lot of chocolate"));
+
+    @Test
+    public void handlesRequestsWithNoCookies() throws Exception {
+        assertThat(cookies(responseWithoutCookies()), isEmpty());
+    }
+
+    @Test
+    public void extractsCookiesFromRequest() throws Exception {
+        assertThat(cookies(responseWithCookies(cookie1, cookie2, cookie3)), containsInAnyOrder(cookie1, cookie2, cookie3));
+    }
+
+    @Test
+    public void ignoresMalformedCookies() throws Exception {
+        Request request = get("/").header(SET_COOKIE, "hello; Path=/malformed;").build();
+        assertThat(cookies(request), isEmpty());
+    }
+
+    private Response responseWithoutCookies() {
+        return responseWithCookies();
+    }
+
+    private Response responseWithCookies(Cookie... cookies) {
+        ResponseBuilder builder = ResponseBuilder.response();
+        for (Cookie cookie : cookies) {
+            builder.cookie(cookie);
+        }
+        return builder.build();
+    }
+}

--- a/test/com/googlecode/utterlyidle/cookies/CookieEncoderTest.java
+++ b/test/com/googlecode/utterlyidle/cookies/CookieEncoderTest.java
@@ -1,0 +1,46 @@
+package com.googlecode.utterlyidle.cookies;
+
+import com.googlecode.utterlyidle.Request;
+import com.googlecode.utterlyidle.Response;
+import com.googlecode.utterlyidle.handlers.RecordingHttpHandler;
+import org.junit.Test;
+
+import static com.googlecode.utterlyidle.RequestBuilder.get;
+import static com.googlecode.utterlyidle.ResponseBuilder.response;
+import static com.googlecode.utterlyidle.cookies.Cookie.cookie;
+import static com.googlecode.utterlyidle.cookies.CookieAttribute.comment;
+import static com.googlecode.utterlyidle.cookies.CookieBuilder.*;
+import static com.googlecode.utterlyidle.cookies.CookieCutter.cookies;
+import static com.googlecode.utterlyidle.handlers.ReturnResponseHandler.returns;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertThat;
+
+public class CookieEncoderTest {
+
+    @Test
+    public void decodesCookieValuesOnRequests() throws Exception {
+        Cookie cookie = cookie("cookie1", "SMWNYiBOxZHhuIM=");
+        Cookie expected = modify(cookie).value("Hōb Nőḃ").build();
+
+        Request request = get("/").cookie(cookie).build();
+        RecordingHttpHandler delegate = RecordingHttpHandler.recordingHttpHandler();
+        CookieEncoder encoder = new CookieEncoder(delegate, new Base64Encoding());
+
+        encoder.handle(request);
+        assertThat(cookies(delegate.lastRequest()), contains(expected));
+    }
+
+    @Test
+    public void encodesCookieValuesOnResponses() throws Exception {
+        Cookie cookie = cookie("cookie1", "Hōb Nőḃ", comment("comment"));
+        Cookie expected = modify(cookie).value("SMWNYiBOxZHhuIM=").build();
+
+        Response response = response().cookie(cookie).build();
+        CookieEncoder encoder = new CookieEncoder(returns(response), new Base64Encoding());
+        assertThat(cookies(encoder.handle(anyRequest())), contains(expected));
+    }
+
+    private Request anyRequest() {
+        return get("/").build();
+    }
+}

--- a/test/com/googlecode/utterlyidle/cookies/CookieEncodingContract.java
+++ b/test/com/googlecode/utterlyidle/cookies/CookieEncodingContract.java
@@ -1,0 +1,24 @@
+package com.googlecode.utterlyidle.cookies;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public abstract class CookieEncodingContract {
+
+    @Test
+    public void encodesValue() throws Exception {
+        String encoded = encoding().encode(input());
+        assertThat(encoded, is(expectedOutput()));
+    }
+
+    @Test
+    public void codecIsSymmetrical() throws Exception {
+        assertThat(encoding().decode(encoding().encode(input())), is(input()));
+    }
+
+    protected abstract String input();
+    protected abstract String expectedOutput();
+    protected abstract CookieEncoding encoding();
+}

--- a/test/com/googlecode/utterlyidle/cookies/EmptyCookiesMatcher.java
+++ b/test/com/googlecode/utterlyidle/cookies/EmptyCookiesMatcher.java
@@ -1,0 +1,27 @@
+package com.googlecode.utterlyidle.cookies;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import static com.googlecode.totallylazy.Sequences.sequence;
+
+public class EmptyCookiesMatcher extends TypeSafeDiagnosingMatcher<Iterable<Cookie>> {
+
+    public static Matcher<Iterable<Cookie>> isEmpty() {
+        return new EmptyCookiesMatcher();
+    }
+
+    private EmptyCookiesMatcher() {
+    }
+
+    @Override
+    protected boolean matchesSafely(Iterable<Cookie> cookies, Description description) {
+        return sequence(cookies).isEmpty();
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("no cookies");
+    }
+}

--- a/test/com/googlecode/utterlyidle/cookies/IdentityEncodingTest.java
+++ b/test/com/googlecode/utterlyidle/cookies/IdentityEncodingTest.java
@@ -1,0 +1,19 @@
+package com.googlecode.utterlyidle.cookies;
+
+public class IdentityEncodingTest extends CookieEncodingContract {
+
+    @Override
+    protected String input() {
+        return "anything";
+    }
+
+    @Override
+    protected String expectedOutput() {
+        return input();
+    }
+
+    @Override
+    protected CookieEncoding encoding() {
+        return new IdentityEncoding();
+    }
+}

--- a/test/com/googlecode/utterlyidle/cookies/UrlEncodingTest.java
+++ b/test/com/googlecode/utterlyidle/cookies/UrlEncodingTest.java
@@ -1,0 +1,17 @@
+package com.googlecode.utterlyidle.cookies;
+
+public class UrlEncodingTest extends CookieEncodingContract {
+
+    @Override
+    protected String input() {
+        return "Hōb Nőḃ";
+    }
+
+    @Override
+    protected String expectedOutput() {
+        return "H%C5%8Db+N%C5%91%E1%B8%83";
+    }
+
+    @Override
+    protected CookieEncoding encoding() { return new UrlEncoding(); }
+}


### PR DESCRIPTION
This is an optional HttpHandler (and encoders) that can be used to support non ASCII characters in Cookies (i.e UTF-8 characters in a Flash message)