### PR TITLE
Added Undertow implementation of RestServer

### DIFF
--- a/build/optional.dependencies
+++ b/build/optional.dependencies
@@ -18,6 +18,13 @@ mvn:org.eclipse.jetty:jetty-servlet:jar|sources:9.2.12.v20150709
 mvn:org.eclipse.jetty:jetty-webapp:jar|sources:9.2.12.v20150709
 mvn:org.eclipse.jetty:jetty-security:jar|sources:9.2.12.v20150709
 
+# Undertow
+mvn:io.undertow:undertow-core:jar|sources:1.2.12.Final
+mvn:io.undertow:undertow-servlet:jar|sources:1.2.12.Final
+mvn:org.jboss.xnio:xnio-api:jar|sources:3.3.2.Final
+mvn:org.jboss.xnio:xnio-nio:jar|sources:3.3.2.Final
+mvn:org.jboss.logging:jboss-logging:jar|sources:3.1.4.GA
+
 mvn:javax.servlet:javax.servlet-api:jar|sources:3.1.0
 
 mvn:org.ccil.cowan.tagsoup:tagsoup:jar:1.2

--- a/src/com/googlecode/utterlyidle/undertow/RestHttpHandler.java
+++ b/src/com/googlecode/utterlyidle/undertow/RestHttpHandler.java
@@ -1,0 +1,98 @@
+package com.googlecode.utterlyidle.undertow;
+
+import com.googlecode.totallylazy.Pair;
+import com.googlecode.totallylazy.functions.Function2;
+import com.googlecode.utterlyidle.Application;
+import com.googlecode.utterlyidle.HeaderParameters;
+import com.googlecode.utterlyidle.HttpHeaders;
+import com.googlecode.utterlyidle.QueryParameters;
+import com.googlecode.utterlyidle.Request;
+import com.googlecode.utterlyidle.Requests;
+import com.googlecode.utterlyidle.Response;
+import com.googlecode.utterlyidle.ResponseBuilder;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HttpString;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import static com.googlecode.totallylazy.Closeables.using;
+import static com.googlecode.totallylazy.Exceptions.printStackTrace;
+import static com.googlecode.totallylazy.Pair.pair;
+import static com.googlecode.totallylazy.Sequences.sequence;
+import static com.googlecode.utterlyidle.ClientAddress.clientAddress;
+import static com.googlecode.utterlyidle.HeaderParameters.headerParameters;
+import static com.googlecode.utterlyidle.MediaType.TEXT_PLAIN;
+import static com.googlecode.utterlyidle.RequestEnricher.requestEnricher;
+import static com.googlecode.utterlyidle.Status.INTERNAL_SERVER_ERROR;
+import static java.lang.Integer.parseInt;
+
+class RestHttpHandler implements HttpHandler {
+    private final Application application;
+
+    public RestHttpHandler(Application application) {
+        this.application = application;
+    }
+
+    @Override
+    public void handleRequest(HttpServerExchange exchange) throws IOException {
+        exchange.startBlocking();
+        Response applicationResponse = getResponse(exchange);
+        mapTo(applicationResponse, exchange);
+    }
+
+    private Response getResponse(HttpServerExchange exchange) {
+        try {
+            return application.handle(request(exchange));
+
+        } catch (Throwable e) {
+            StringWriter stringWriter = new StringWriter();
+            using(new PrintWriter(stringWriter), printStackTrace(e));
+            return ResponseBuilder.response(INTERNAL_SERVER_ERROR).
+                    contentType(TEXT_PLAIN).
+                    entity(stringWriter.toString()).
+                    build();
+        }
+    }
+
+    private void mapTo(Response applicationResponse, HttpServerExchange exchange) throws IOException {
+        exchange.setResponseCode(applicationResponse.status().code());
+        sequence(applicationResponse.headers()).fold(exchange, mapHeaders());
+        for (String integer : applicationResponse.headers().valueOption(HttpHeaders.CONTENT_LENGTH)) {
+            exchange.setResponseContentLength(parseInt(integer));
+        }
+        using(exchange.getOutputStream(), applicationResponse.entity().writer());
+    }
+
+    private Function2<HttpServerExchange, Pair<String, String>, HttpServerExchange> mapHeaders() {
+        return (exchange, applicationHeader) -> {
+            exchange.getResponseHeaders().add(new HttpString(applicationHeader.first()), applicationHeader.second());
+            return exchange;
+        };
+    }
+
+    private Request request(HttpServerExchange exchange) throws IOException {
+        Request request = Requests.request(
+                exchange.getRequestMethod().toString(),
+                exchange.getRequestPath(),
+                query(exchange),
+                headers(exchange),
+                exchange.getInputStream());
+        return requestEnricher(
+                clientAddress(exchange.getSourceAddress().getAddress()),
+                exchange.getRequestScheme())
+                .enrich(request);
+    }
+
+    private HeaderParameters headers(HttpServerExchange exchange) {
+        return headerParameters(sequence(exchange.getRequestHeaders())
+                .flatMap(headerValues -> sequence(headerValues)
+                        .map(headerValue -> pair(headerValues.getHeaderName().toString(), headerValue))));
+    }
+
+    private QueryParameters query(HttpServerExchange exchange) {
+        return QueryParameters.parse(exchange.getQueryString());
+    }
+}

--- a/src/com/googlecode/utterlyidle/undertow/RestServer.java
+++ b/src/com/googlecode/utterlyidle/undertow/RestServer.java
@@ -1,0 +1,111 @@
+package com.googlecode.utterlyidle.undertow;
+
+import com.googlecode.totallylazy.Option;
+import com.googlecode.totallylazy.Sequences;
+import com.googlecode.totallylazy.io.Uri;
+import com.googlecode.utterlyidle.Application;
+import com.googlecode.utterlyidle.ApplicationBuilder;
+import com.googlecode.utterlyidle.ServerConfiguration;
+import com.googlecode.utterlyidle.examples.HelloWorldApplication;
+import com.googlecode.utterlyidle.services.Service;
+import io.undertow.Undertow;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.ServerSocket;
+import java.util.List;
+
+import static com.googlecode.totallylazy.Option.none;
+import static com.googlecode.totallylazy.Option.option;
+import static com.googlecode.totallylazy.functions.Time0.calculateMilliseconds;
+import static com.googlecode.utterlyidle.ServerConfiguration.defaultConfiguration;
+import static java.lang.String.format;
+import static java.lang.System.nanoTime;
+
+public class RestServer implements com.googlecode.utterlyidle.Server {
+    private final Application application;
+    private final Undertow server;
+
+    private Uri uri;
+
+    public RestServer(Application application, ServerConfiguration configuration) throws Exception {
+        this.application = application;
+
+        server = startApp(application, configuration);
+    }
+
+    @Override
+    public Application application() {
+        return application;
+    }
+
+    @Override
+    public Uri uri() {
+        return uri;
+    }
+
+    @Override
+    public void close() throws IOException {
+        server.stop();
+    }
+
+    public static void main(String[] args) throws Exception {
+        ApplicationBuilder.application(HelloWorldApplication.class).start(defaultConfiguration().port(8002));
+    }
+
+    private Undertow startApp(Application application, ServerConfiguration configuration) throws Exception {
+        long start = nanoTime();
+        Undertow server = startUpServer(application, configuration);
+        System.out.println(format("Listening on %s, started Undertow in %s msecs", uri, calculateMilliseconds(start, nanoTime())));
+        Service.functions.start().callConcurrently(this.application);
+        return server;
+    }
+
+    private Undertow startUpServer(Application application, ServerConfiguration configuration) throws Exception {
+        Undertow server = Undertow.builder()
+                .addHttpListener(configuration.port(), configuration.bindAddress().getHostAddress())
+                .setWorkerThreads(configuration.maxThreadNumber())
+                .setHandler(new RestHttpHandler(application))
+                .build();
+        server.start();
+
+        uri = configuration.port(findPortInUse(server)).toUrl();
+
+        return server;
+    }
+
+    private int findPortInUse(Undertow server) {
+        return declaredField(server, "channels")
+                .map(field -> listValueOf(field, server))
+                .map(Sequences::sequence)
+                .flatMap(channels -> channels
+                        .flatMap(this::portFrom)
+                        .headOption())
+                .getOrThrow(new IllegalStateException("Cannot find port from Undertow"));
+    }
+
+    private Option<Integer> portFrom(Object channel) throws Exception {
+        return declaredField(channel, "socket")
+                .map(socketField -> (ServerSocket) socketField.get(channel))
+                .map(ServerSocket::getLocalPort);
+    }
+
+    private List<Object> listValueOf(Field field, Object object) {
+        try {
+            return (List<Object>) field.get(object);
+        } catch (IllegalAccessException e) {
+            return null;
+        }
+    }
+
+    private Option<Field> declaredField(Object object, String fieldName) {
+        try {
+            Field field = object.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return option(field);
+        } catch (NoSuchFieldException e) {
+            return none();
+        }
+    }
+
+}

--- a/test/com/googlecode/utterlyidle/undertow/RestServerTest.java
+++ b/test/com/googlecode/utterlyidle/undertow/RestServerTest.java
@@ -1,0 +1,10 @@
+package com.googlecode.utterlyidle.undertow;
+
+import com.googlecode.utterlyidle.ServerContract;
+
+public class RestServerTest extends ServerContract<RestServer> {
+    @Override
+    protected Class<RestServer> server() throws Exception {
+        return RestServer.class;
+    }
+}


### PR DESCRIPTION
We've (I've?) been wanting to play a bit with [Undertow](http://undertow.io/), so I've added an appropriate RestServer implementation. 

It's pretty straightforward, with the exception that the ephemeral port isn't exposed. As such, there's some nasty reflection in there to extract this, which makes me very sad indeed but seems to be the same approach others are using to accomplish this (e.g. Spring Boot). It still makes me sad.