### PR TITLE
Java 7 - Undertow support, and fix for multiple content encodings via GzipHandler

### DIFF
--- a/build/optional.dependencies
+++ b/build/optional.dependencies
@@ -18,6 +18,13 @@ mvn:org.eclipse.jetty:jetty-servlet:jar|sources:9.2.12.v20150709
 mvn:org.eclipse.jetty:jetty-webapp:jar|sources:9.2.12.v20150709
 mvn:org.eclipse.jetty:jetty-security:jar|sources:9.2.12.v20150709
 
+# Undertow
+mvn:io.undertow:undertow-core:jar|sources:1.2.12.Final
+mvn:io.undertow:undertow-servlet:jar|sources:1.2.12.Final
+mvn:org.jboss.xnio:xnio-api:jar|sources:3.3.2.Final
+mvn:org.jboss.xnio:xnio-nio:jar|sources:3.3.2.Final
+mvn:org.jboss.logging:jboss-logging:jar|sources:3.1.4.GA
+
 mvn:javax.servlet:javax.servlet-api:jar|sources:3.1.0
 
 mvn:org.ccil.cowan.tagsoup:tagsoup:jar:1.2

--- a/src/com/googlecode/utterlyidle/handlers/GzipHandler.java
+++ b/src/com/googlecode/utterlyidle/handlers/GzipHandler.java
@@ -38,7 +38,7 @@ public class GzipHandler implements HttpHandler {
                 !marker.isInternal(request) &&
                 response.entity().length().is(greaterThan(0)) &&
                 gZipPolicy.matches(pair(request, response))) {
-            return builder.header(CONTENT_ENCODING, GZIP).entity(GZip.gzip(response.entity().asBytes())).build();
+            return builder.replaceHeaders(CONTENT_ENCODING, GZIP).entity(GZip.gzip(response.entity().asBytes())).build();
         }
         return builder.build();
     }

--- a/src/com/googlecode/utterlyidle/undertow/RestHttpHandler.java
+++ b/src/com/googlecode/utterlyidle/undertow/RestHttpHandler.java
@@ -1,0 +1,108 @@
+package com.googlecode.utterlyidle.undertow;
+
+import com.googlecode.totallylazy.Callable2;
+import com.googlecode.totallylazy.Pair;
+import com.googlecode.utterlyidle.Application;
+import com.googlecode.utterlyidle.HeaderParameters;
+import com.googlecode.utterlyidle.HttpHeaders;
+import com.googlecode.utterlyidle.QueryParameters;
+import com.googlecode.utterlyidle.Request;
+import com.googlecode.utterlyidle.Requests;
+import com.googlecode.utterlyidle.Response;
+import com.googlecode.utterlyidle.ResponseBuilder;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HeaderValues;
+import io.undertow.util.HttpString;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.googlecode.totallylazy.Closeables.using;
+import static com.googlecode.totallylazy.Exceptions.printStackTrace;
+import static com.googlecode.totallylazy.Pair.pair;
+import static com.googlecode.totallylazy.Sequences.sequence;
+import static com.googlecode.utterlyidle.ClientAddress.clientAddress;
+import static com.googlecode.utterlyidle.HeaderParameters.headerParameters;
+import static com.googlecode.utterlyidle.MediaType.TEXT_PLAIN;
+import static com.googlecode.utterlyidle.RequestEnricher.requestEnricher;
+import static com.googlecode.utterlyidle.Status.INTERNAL_SERVER_ERROR;
+import static java.lang.Integer.parseInt;
+
+class RestHttpHandler implements HttpHandler {
+    private final Application application;
+
+    public RestHttpHandler(Application application) {
+        this.application = application;
+    }
+
+    @Override
+    public void handleRequest(HttpServerExchange exchange) throws IOException {
+        exchange.startBlocking();
+        Response applicationResponse = getResponse(exchange);
+        mapTo(applicationResponse, exchange);
+    }
+
+    private Response getResponse(HttpServerExchange exchange) {
+        try {
+            return application.handle(request(exchange));
+
+        } catch (Throwable e) {
+            StringWriter stringWriter = new StringWriter();
+            using(new PrintWriter(stringWriter), printStackTrace(e));
+            return ResponseBuilder.response(INTERNAL_SERVER_ERROR).
+                    contentType(TEXT_PLAIN).
+                    entity(stringWriter.toString()).
+                    build();
+        }
+    }
+
+    private void mapTo(Response applicationResponse, HttpServerExchange exchange) throws IOException {
+        exchange.setResponseCode(applicationResponse.status().code());
+        sequence(applicationResponse.headers()).fold(exchange, mapHeaders());
+        for (String integer : applicationResponse.headers().valueOption(HttpHeaders.CONTENT_LENGTH)) {
+            exchange.setResponseContentLength(parseInt(integer));
+        }
+        using(exchange.getOutputStream(), applicationResponse.entity().writer());
+    }
+
+    private Callable2<HttpServerExchange, Pair<String, String>, HttpServerExchange> mapHeaders() {
+        return new Callable2<HttpServerExchange, Pair<String, String>, HttpServerExchange>() {
+            @Override
+            public HttpServerExchange call(final HttpServerExchange exchange, final Pair<String, String> applicationHeader) throws Exception {
+                exchange.getResponseHeaders().add(new HttpString(applicationHeader.first()), applicationHeader.second());
+                return exchange;
+            }
+        };
+    }
+
+    private Request request(HttpServerExchange exchange) throws IOException {
+        Request request = Requests.request(
+                exchange.getRequestMethod().toString(),
+                exchange.getRequestPath(),
+                query(exchange),
+                headers(exchange),
+                exchange.getInputStream());
+        return requestEnricher(
+                clientAddress(exchange.getSourceAddress().getAddress()),
+                exchange.getRequestScheme())
+                .enrich(request);
+    }
+
+    private HeaderParameters headers(HttpServerExchange exchange) {
+        List<Pair<String, String>> headers = new ArrayList<>();
+        for (HeaderValues requestHeader : exchange.getRequestHeaders()) {
+            for (String headerValue : requestHeader) {
+                headers.add(pair(requestHeader.getHeaderName().toString(), headerValue));
+            }
+        }
+        return headerParameters(headers);
+    }
+
+    private QueryParameters query(HttpServerExchange exchange) {
+        return QueryParameters.parse(exchange.getQueryString());
+    }
+}

--- a/src/com/googlecode/utterlyidle/undertow/RestServer.java
+++ b/src/com/googlecode/utterlyidle/undertow/RestServer.java
@@ -1,0 +1,123 @@
+package com.googlecode.utterlyidle.undertow;
+
+import com.googlecode.totallylazy.Option;
+import com.googlecode.totallylazy.Sequence;
+import com.googlecode.totallylazy.Sequences;
+import com.googlecode.totallylazy.Uri;
+import com.googlecode.utterlyidle.Application;
+import com.googlecode.utterlyidle.ApplicationBuilder;
+import com.googlecode.utterlyidle.ServerConfiguration;
+import com.googlecode.utterlyidle.examples.HelloWorldApplication;
+import com.googlecode.utterlyidle.services.Service;
+import io.undertow.Undertow;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.ServerSocket;
+import java.util.List;
+
+import static com.googlecode.totallylazy.Option.none;
+import static com.googlecode.totallylazy.Option.option;
+import static com.googlecode.totallylazy.Sequences.sequence;
+import static com.googlecode.totallylazy.callables.TimeCallable.calculateMilliseconds;
+import static com.googlecode.utterlyidle.ServerConfiguration.defaultConfiguration;
+import static java.lang.String.format;
+import static java.lang.System.nanoTime;
+
+public class RestServer implements com.googlecode.utterlyidle.Server {
+    private final Application application;
+    private final Undertow server;
+
+    private Uri uri;
+
+    public RestServer(Application application, ServerConfiguration configuration) throws Exception {
+        this.application = application;
+
+        server = startApp(application, configuration);
+    }
+
+    @Override
+    public Application application() {
+        return application;
+    }
+
+    @Override
+    public Uri uri() {
+        return uri;
+    }
+
+    @Override
+    public void close() throws IOException {
+        server.stop();
+    }
+
+    public static void main(String[] args) throws Exception {
+        ApplicationBuilder.application(HelloWorldApplication.class).start(defaultConfiguration().port(8002));
+    }
+
+    private Undertow startApp(Application application, ServerConfiguration configuration) throws Exception {
+        long start = nanoTime();
+        Undertow server = startUpServer(application, configuration);
+        System.out.println(format("Listening on %s, started Undertow in %s msecs", uri, calculateMilliseconds(start, nanoTime())));
+        Service.functions.start().callConcurrently(this.application);
+        return server;
+    }
+
+    private Undertow startUpServer(Application application, ServerConfiguration configuration) throws Exception {
+        Undertow server = Undertow.builder()
+                .addHttpListener(configuration.port(), configuration.bindAddress().getHostAddress())
+                .setWorkerThreads(configuration.maxThreadNumber())
+                .setHandler(new RestHttpHandler(application))
+                .build();
+        server.start();
+
+        uri = configuration.port(findPortInUse(server)).toUrl();
+
+        return server;
+    }
+
+    private int findPortInUse(Undertow server) {
+        for (Object channel : listValueOf(declaredField(server, "channels"), server)) {
+            Option<Integer> port = portFrom(channel);
+            if (port.isDefined()) {
+                return port.get();
+            }
+        }
+        throw new IllegalStateException("Cannot find port from Undertow");
+    }
+
+    private Option<Integer> portFrom(Object channel) {
+        Option<Field> socketField = declaredField(channel, "socket");
+        if (socketField.isDefined()) {
+            try {
+                return option(((ServerSocket) socketField.get().get(channel)).getLocalPort());
+            } catch (IllegalAccessException ignored) {
+                // ignored
+            }
+        }
+        return none();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Sequence<Object> listValueOf(Option<Field> field, Object object) {
+        try {
+            if (field.isDefined()) {
+                return sequence((List<Object>) field.get().get(object));
+            }
+        } catch (IllegalAccessException ignored) {
+            // ignored
+        }
+        return Sequences.empty();
+    }
+
+    private Option<Field> declaredField(Object object, String fieldName) {
+        try {
+            Field field = object.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return option(field);
+        } catch (NoSuchFieldException e) {
+            return none();
+        }
+    }
+
+}

--- a/test/com/googlecode/utterlyidle/handlers/GzipHandlerTest.java
+++ b/test/com/googlecode/utterlyidle/handlers/GzipHandlerTest.java
@@ -1,26 +1,49 @@
 package com.googlecode.utterlyidle.handlers;
 
 import com.googlecode.utterlyidle.InternalRequestMarker;
+import com.googlecode.utterlyidle.MediaType;
+import com.googlecode.utterlyidle.ResponseBuilder;
+import com.googlecode.utterlyidle.sitemesh.ContentTypePredicate;
 import org.junit.Test;
 
 import static com.googlecode.totallylazy.matchers.Matchers.is;
 import static com.googlecode.utterlyidle.HttpHeaders.ACCEPT_ENCODING;
+import static com.googlecode.utterlyidle.HttpHeaders.CONTENT_ENCODING;
+import static com.googlecode.utterlyidle.HttpHeaders.CONTENT_TYPE;
 import static com.googlecode.utterlyidle.HttpHeaders.VARY;
+import static com.googlecode.utterlyidle.MediaType.TEXT_PLAIN;
 import static com.googlecode.utterlyidle.RequestBuilder.get;
 import static com.googlecode.utterlyidle.Responses.response;
 import static com.googlecode.utterlyidle.handlers.ApplicationId.applicationId;
 import static com.googlecode.utterlyidle.handlers.GZipPolicy.gZipPolicy;
 import static com.googlecode.utterlyidle.handlers.GzipHandler.GZIP;
 import static com.googlecode.utterlyidle.handlers.ReturnResponseHandler.returns;
+import static com.googlecode.utterlyidle.sitemesh.ContentTypePredicate.contentType;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class GzipHandlerTest {
+
     @Test
     public void alwaysAddsVaryHeaderSoCachesCanWorkCorrectly() throws Exception {
         GzipHandler handler = new GzipHandler(returns(response()), new InternalRequestMarker(applicationId()), gZipPolicy());
 
         assertThat(handler.handle(get("ignored").build()).headers().getValue(VARY), is(ACCEPT_ENCODING));
         assertThat(handler.handle(get("ignored").header(ACCEPT_ENCODING, GZIP).build()).headers().getValue(VARY), is(ACCEPT_ENCODING));
+    }
+
+    @Test
+    public void contentEncodingHeaderIsReplaced() throws Exception {
+        GzipHandler handler = new GzipHandler(
+                returns(ResponseBuilder.response()
+                        .header(CONTENT_ENCODING, "an-encoding")
+                        .header(CONTENT_TYPE, TEXT_PLAIN)
+                        .entity("some content")
+                        .build()),
+                new InternalRequestMarker(applicationId()), gZipPolicy().add(contentType(TEXT_PLAIN)));
+
+        assertThat(
+                handler.handle(get("ignored").header(ACCEPT_ENCODING, GZIP).build()).headers().getValue(CONTENT_ENCODING),
+                is(GZIP));
     }
 
 }

--- a/test/com/googlecode/utterlyidle/undertow/RestServerTest.java
+++ b/test/com/googlecode/utterlyidle/undertow/RestServerTest.java
@@ -1,0 +1,10 @@
+package com.googlecode.utterlyidle.undertow;
+
+import com.googlecode.utterlyidle.ServerContract;
+
+public class RestServerTest extends ServerContract<RestServer> {
+    @Override
+    protected Class<RestServer> server() throws Exception {
+        return RestServer.class;
+    }
+}


### PR DESCRIPTION
Two things here:

* Looks like I added Undertow support for the Java7 branch, and never did a pull request. Whoops.
* The GzipHandler always *adds* the Content-Encoding. This means you can end up with multiple Content-Encoding headers with some RestServers (e.g. Jetty 9), which will break Webkit based browsers (at least Chrome and Safari) - they'll just display the raw Gzip.