### PR TITLE
Test for multiple Content-Encoding headers with GzipHandler

### DIFF
--- a/test/com/googlecode/utterlyidle/handlers/GzipHandlerTest.java
+++ b/test/com/googlecode/utterlyidle/handlers/GzipHandlerTest.java
@@ -8,22 +8,39 @@ import org.junit.Test;
 
 import static com.googlecode.totallylazy.matchers.Matchers.is;
 import static com.googlecode.utterlyidle.HttpHeaders.ACCEPT_ENCODING;
+import static com.googlecode.utterlyidle.HttpHeaders.CONTENT_ENCODING;
+import static com.googlecode.utterlyidle.HttpHeaders.CONTENT_TYPE;
 import static com.googlecode.utterlyidle.HttpHeaders.VARY;
-import static com.googlecode.utterlyidle.Request.get;
-import static com.googlecode.utterlyidle.HttpMessage.Builder.header;
+import static com.googlecode.utterlyidle.MediaType.TEXT_PLAIN;
 import static com.googlecode.utterlyidle.handlers.ApplicationId.applicationId;
 import static com.googlecode.utterlyidle.handlers.GZipPolicy.gZipPolicy;
 import static com.googlecode.utterlyidle.handlers.GzipHandler.GZIP;
 import static com.googlecode.utterlyidle.handlers.ReturnResponseHandler.returns;
+import static com.googlecode.utterlyidle.sitemesh.ContentTypePredicate.contentType;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class GzipHandlerTest {
+
     @Test
     public void alwaysAddsVaryHeaderSoCachesCanWorkCorrectly() throws Exception {
         GzipHandler handler = new GzipHandler(returns(Response.ok()), new InternalRequestMarker(applicationId()), gZipPolicy());
 
         assertThat(handler.handle(Request.get("ignored")).headers().getValue(VARY), is(ACCEPT_ENCODING));
         assertThat(handler.handle(Request.get("ignored", HttpMessage.Builder.header(ACCEPT_ENCODING, GZIP))).headers().getValue(VARY), is(ACCEPT_ENCODING));
+    }
+
+    @Test
+    public void contentEncodingHeaderIsReplaced() throws Exception {
+        GzipHandler handler = new GzipHandler(
+                returns(Response.ok()
+                        .header(CONTENT_ENCODING, "an-encoding")
+                        .header(CONTENT_TYPE, TEXT_PLAIN)
+                        .entity("some content")),
+                new InternalRequestMarker(applicationId()), gZipPolicy().add(contentType(TEXT_PLAIN)));
+
+        assertThat(
+                handler.handle(Request.get("ignored").header(ACCEPT_ENCODING, GZIP)).headers().getValue(CONTENT_ENCODING),
+                is(GZIP));
     }
 
 }


### PR DESCRIPTION
This just adds another test to cover the multiple Content-Encoding headers case in my Java7 branch pull request. It looks like you've already solved the problem in the master impl :smile: