### PR TITLE
Add system property to suppress exceptionhandler's dumping of exceptions

### DIFF
--- a/src/com/googlecode/utterlyidle/handlers/ExceptionHandler.java
+++ b/src/com/googlecode/utterlyidle/handlers/ExceptionHandler.java
@@ -9,10 +9,13 @@ import com.googlecode.utterlyidle.rendering.ExceptionRenderer;
 import java.lang.reflect.InvocationTargetException;
 
 import static com.googlecode.totallylazy.Debug.debugging;
+import static com.googlecode.totallylazy.Option.option;
 import static com.googlecode.utterlyidle.MediaType.TEXT_PLAIN;
 import static com.googlecode.utterlyidle.Status.INTERNAL_SERVER_ERROR;
 
 public class ExceptionHandler implements HttpHandler {
+    private static final String LOG_PROPERTY = "com.googlecode.utterlyidle.exceptions.log";
+
     private final HttpHandler httpHandler;
     private final ResponseHandlersFinder handlers;
 
@@ -34,7 +37,7 @@ public class ExceptionHandler implements HttpHandler {
     }
 
     private Response findAndHandle(Request request, Throwable throwable) {
-        if (debugging()) throwable.printStackTrace();
+        if (debugging() && shouldLogExceptions()) throwable.printStackTrace();
         final Response response = Response.response(INTERNAL_SERVER_ERROR).
                 contentType(TEXT_PLAIN).
                 entity(throwable);
@@ -43,5 +46,11 @@ public class ExceptionHandler implements HttpHandler {
         } catch (Throwable t) {
             return response.entity(ExceptionRenderer.toString(t));
         }
+    }
+
+    private boolean shouldLogExceptions() {
+        return option(System.getProperty(LOG_PROPERTY))
+                .map(Boolean::parseBoolean)
+                .getOrElse(true);
     }
 }

--- a/test/com/googlecode/utterlyidle/handlers/ExceptionHandlerTest.java
+++ b/test/com/googlecode/utterlyidle/handlers/ExceptionHandlerTest.java
@@ -1,0 +1,73 @@
+package com.googlecode.utterlyidle.handlers;
+
+import com.googlecode.totallylazy.StringPrintStream;
+import com.googlecode.utterlyidle.HttpHandler;
+import com.googlecode.yadic.SimpleContainer;
+import org.hamcrest.Matcher;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.googlecode.utterlyidle.Request.get;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assume.assumeThat;
+import static java.lang.management.ManagementFactory.getRuntimeMXBean;
+
+public class ExceptionHandlerTest {
+
+    private final StringPrintStream stdErr = new StringPrintStream();
+
+    private ExceptionHandler underTest;
+
+    @Before
+    public void setUp() {
+        underTest = new ExceptionHandler(exceptionThrowingHandler(),
+                new ResponseHandlersFinder(new ResponseHandlers(), new SimpleContainer()));
+        System.setErr(stdErr);
+    }
+
+    @Test
+    public void exceptionsAreNotPrintedToSystemErrorWhenJvmDebuggingIsDisabled() throws Exception {
+        assumeThat(jvmArguments(), not(containsDebuggingAgent()));
+
+        underTest.handle(get("/"));
+
+        assertThat(stdErr.toString(), not(containsString("aTestException")));
+    }
+
+    @Test
+    public void exceptionsArePrintedToSystemErrorWhenJvmDebuggingIsEnabled() throws Exception {
+        assumeThat(jvmArguments(), containsDebuggingAgent());
+
+        underTest.handle(get("/"));
+
+        assertThat(stdErr.toString(), containsString("aTestException"));
+    }
+
+    @Test
+    public void exceptionsAreNotPrintedToSystemErrorWhenJvmDebuggingIsEnabledAndSuppressionArgumentIsPresent() throws Exception {
+        assumeThat(jvmArguments(), containsDebuggingAgent());
+        System.setProperty("com.googlecode.utterlyidle.exceptions.log", "false");
+
+        underTest.handle(get("/"));
+
+        assertThat(stdErr.toString(), not(containsString("aTestException")));
+    }
+
+    private Matcher<String> containsDebuggingAgent() {
+        return containsString("-agentlib:jdwp");
+    }
+
+    private String jvmArguments() {
+        return getRuntimeMXBean().getInputArguments().toString();
+    }
+
+    private HttpHandler exceptionThrowingHandler() {
+        return request -> {
+            throw new RuntimeException("aTestException");
+        };
+    }
+
+
+}


### PR DESCRIPTION
This will suppress the SystemErr dump of exceptions from `ExceptionHandler` when the system property `com.googlecode.utterlyidle.exceptions.log` is `false`.

The rests are dependent on the state of the JVM, which is a bit messy. But without refactor `Debug` to be injectable I couldn't think of a nice way around this.