### PR TITLE
Add system property to suppress exceptionhandler's dumping of exceptions

### DIFF
--- a/src/com/googlecode/utterlyidle/handlers/ExceptionHandler.java
+++ b/src/com/googlecode/utterlyidle/handlers/ExceptionHandler.java
@@ -14,6 +14,8 @@ import static com.googlecode.utterlyidle.MediaType.TEXT_PLAIN;
 import static com.googlecode.utterlyidle.Status.INTERNAL_SERVER_ERROR;
 
 public class ExceptionHandler implements HttpHandler {
+    private static final String LOG_PROPERTY = "com.googlecode.utterlyidle.exceptions.log";
+
     private final HttpHandler httpHandler;
     private final ResponseHandlersFinder handlers;
 
@@ -35,7 +37,7 @@ public class ExceptionHandler implements HttpHandler {
     }
 
     private Response findAndHandle(Request request, Throwable throwable) {
-        if (debugging()) throwable.printStackTrace();
+        if (debugging() && shouldLogExceptions()) throwable.printStackTrace();
         ResponseBuilder response = ResponseBuilder.response(INTERNAL_SERVER_ERROR).
                 contentType(TEXT_PLAIN).
                 entity(throwable);
@@ -44,5 +46,10 @@ public class ExceptionHandler implements HttpHandler {
         } catch (Throwable t) {
             return response.entity(ExceptionRenderer.toString(t)).build();
         }
+    }
+
+    private boolean shouldLogExceptions() {
+        String logValue = System.getProperty(LOG_PROPERTY);
+        return logValue == null || Boolean.parseBoolean(logValue);
     }
 }

--- a/test/com/googlecode/utterlyidle/handlers/ExceptionHandlerTest.java
+++ b/test/com/googlecode/utterlyidle/handlers/ExceptionHandlerTest.java
@@ -1,0 +1,78 @@
+package com.googlecode.utterlyidle.handlers;
+
+import com.googlecode.totallylazy.StringPrintStream;
+import com.googlecode.utterlyidle.HttpHandler;
+import com.googlecode.utterlyidle.Request;
+import com.googlecode.utterlyidle.Response;
+import com.googlecode.yadic.SimpleContainer;
+import org.hamcrest.Matcher;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.googlecode.utterlyidle.RequestBuilder.get;
+import static java.lang.management.ManagementFactory.getRuntimeMXBean;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assume.assumeThat;
+
+public class ExceptionHandlerTest {
+
+    private final StringPrintStream stdErr = new StringPrintStream();
+
+    private ExceptionHandler underTest;
+
+    @Before
+    public void setUp() {
+        underTest = new ExceptionHandler(exceptionThrowingHandler(),
+                new ResponseHandlersFinder(new ResponseHandlers(), new SimpleContainer()));
+        System.setErr(stdErr);
+    }
+
+    @Test
+    public void exceptionsAreNotPrintedToSystemErrorWhenJvmDebuggingIsDisabled() throws Exception {
+        assumeThat(jvmArguments(), not(containsDebuggingAgent()));
+
+        underTest.handle(get("/").build());
+
+        assertThat(stdErr.toString(), not(containsString("aTestException")));
+    }
+
+    @Test
+    public void exceptionsArePrintedToSystemErrorWhenJvmDebuggingIsEnabled() throws Exception {
+        assumeThat(jvmArguments(), containsDebuggingAgent());
+
+        underTest.handle(get("/").build());
+
+        assertThat(stdErr.toString(), containsString("aTestException"));
+    }
+
+    @Test
+    public void exceptionsAreNotPrintedToSystemErrorWhenJvmDebuggingIsEnabledAndSuppressionArgumentIsPresent() throws Exception {
+        assumeThat(jvmArguments(), containsDebuggingAgent());
+        System.setProperty("com.googlecode.utterlyidle.exceptions.log", "false");
+
+        underTest.handle(get("/").build());
+
+        assertThat(stdErr.toString(), not(containsString("aTestException")));
+    }
+
+    private Matcher<String> containsDebuggingAgent() {
+        return containsString("-agentlib:jdwp");
+    }
+
+    private String jvmArguments() {
+        return getRuntimeMXBean().getInputArguments().toString();
+    }
+
+    private HttpHandler exceptionThrowingHandler() {
+        return new HttpHandler() {
+            @Override
+            public Response handle(final Request request) throws Exception {
+                throw new RuntimeException("aTestException");
+            }
+        };
+    }
+
+
+}


### PR DESCRIPTION
This will suppress the SystemErr dump of exceptions from `ExceptionHandler` when the system property `com.googlecode.utterlyidle.exceptions.log` is `false`.

The rests are dependent on the state of the JVM, which is a bit messy. But without refactor `Debug` to be injectable I couldn't think of a nice way around this.