### PR TITLE
Allow customisation of Flash cookie attributes

### DIFF
--- a/src/com/googlecode/utterlyidle/flash/FlashCookieAttributes.java
+++ b/src/com/googlecode/utterlyidle/flash/FlashCookieAttributes.java
@@ -1,0 +1,45 @@
+package com.googlecode.utterlyidle.flash;
+
+import com.googlecode.totallylazy.Sequence;
+import com.googlecode.utterlyidle.BasePath;
+import com.googlecode.utterlyidle.cookies.CookieAttribute;
+
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+
+import static com.googlecode.totallylazy.Sequences.sequence;
+import static com.googlecode.utterlyidle.cookies.CookieAttribute.path;
+
+public class FlashCookieAttributes implements Iterable<CookieAttribute> {
+
+    private final Sequence<CookieAttribute> cookieAttributes;
+
+    public FlashCookieAttributes(BasePath basePath) {
+        this(basePath, new CookieAttribute[0]);
+    }
+
+    private FlashCookieAttributes(BasePath basePath, CookieAttribute... cookieAttributes) {
+        this.cookieAttributes = sequence(cookieAttributes)
+                .append(path(basePath.toString()));
+    }
+
+    public static FlashCookieAttributes flashCookieAttributes(BasePath basePath, CookieAttribute... cookieAttributes) {
+        return new FlashCookieAttributes(basePath, cookieAttributes);
+    }
+
+    @Override
+    public Iterator<CookieAttribute> iterator() {
+        return cookieAttributes.iterator();
+    }
+
+    @Override
+    public void forEach(final Consumer<? super CookieAttribute> action) {
+        cookieAttributes.forEach(action);
+    }
+
+    @Override
+    public Spliterator<CookieAttribute> spliterator() {
+        return cookieAttributes.spliterator();
+    }
+}

--- a/src/com/googlecode/utterlyidle/flash/FlashHandler.java
+++ b/src/com/googlecode/utterlyidle/flash/FlashHandler.java
@@ -1,27 +1,28 @@
 package com.googlecode.utterlyidle.flash;
 
 import com.googlecode.funclate.Model;
-import com.googlecode.utterlyidle.BasePath;
+import com.googlecode.totallylazy.Sequence;
 import com.googlecode.utterlyidle.HttpHandler;
 import com.googlecode.utterlyidle.Request;
 import com.googlecode.utterlyidle.Response;
 import com.googlecode.utterlyidle.cookies.Cookie;
+import com.googlecode.utterlyidle.cookies.CookieAttribute;
 import com.googlecode.utterlyidle.cookies.CookieParameters;
 
 import static com.googlecode.funclate.json.Json.toJson;
 import static com.googlecode.totallylazy.Pair.pair;
+import static com.googlecode.totallylazy.Sequences.sequence;
 import static com.googlecode.totallylazy.Strings.isBlank;
 import static com.googlecode.utterlyidle.Requests.cookies;
 import static com.googlecode.utterlyidle.ResponseBuilder.modify;
-import static com.googlecode.utterlyidle.cookies.CookieAttribute.path;
 
 public class FlashHandler implements HttpHandler {
-	public static final String FLASH_COOKIE = "f";
-	private static final String EMPTY_FLASH_COOKIE_JSON = "{}";
-	private final HttpHandler decorated;
-	private final Flash flash;
-	private final ClearFlashPredicate clearFlashPredicate;
-    private final BasePath basePath;
+    public static final String FLASH_COOKIE = "f";
+    private static final String EMPTY_FLASH_COOKIE_JSON = "{}";
+    private final HttpHandler decorated;
+    private final Flash flash;
+    private final ClearFlashPredicate clearFlashPredicate;
+    private final FlashCookieAttributes flashCookieAttributes;
 
     /**
 	 * Flash is request-scoped storage for values
@@ -36,61 +37,66 @@ public class FlashHandler implements HttpHandler {
      *
      * It is expected that this behaviour will be superseded by a
      * more fully-featured implementation in the future.
-     *
-	 */
-	public FlashHandler(Flash flash, HttpHandler decorated, ClearFlashPredicate clearFlashPredicate, BasePath basePath) {
-		this.flash = flash;
-		this.decorated = decorated;
-		this.clearFlashPredicate = clearFlashPredicate;
-        this.basePath = basePath;
+     */
+    public FlashHandler(Flash flash, HttpHandler decorated, ClearFlashPredicate clearFlashPredicate, FlashCookieAttributes flashCookieAttributes) {
+        this.flash = flash;
+        this.decorated = decorated;
+        this.clearFlashPredicate = clearFlashPredicate;
+        this.flashCookieAttributes = flashCookieAttributes;
     }
 
-	@Override
-	public Response handle(Request request) throws Exception {
-		setIncomingFlashValues(request, flash);
-		return setFlashCookie(request, decorated.handle(request));
-	}
+    @Override
+    public Response handle(Request request) throws Exception {
+        setIncomingFlashValues(request, flash);
+        return setFlashCookie(request, decorated.handle(request));
+    }
 
-	private static void setIncomingFlashValues(Request request, Flash flash) {
-		CookieParameters requestCookies = cookies(request);
+    private static void setIncomingFlashValues(Request request, Flash flash) {
+        CookieParameters requestCookies = cookies(request);
 
-		if(!requestCookies.contains(FLASH_COOKIE) || isEmptyJson(requestCookies.getValue(FLASH_COOKIE)) || isBlank(requestCookies.getValue(FLASH_COOKIE))) return;
+        if (!requestCookies.contains(FLASH_COOKIE) || isEmptyJson(requestCookies.getValue(FLASH_COOKIE)) || isBlank(requestCookies.getValue(FLASH_COOKIE)))
+            return;
 
-		flash.merge(Model.persistent.parse(requestCookies.getValue(FLASH_COOKIE)));
-	}
+        flash.merge(Model.persistent.parse(requestCookies.getValue(FLASH_COOKIE)));
+    }
 
-	private Response setFlashCookie(Request request, Response response) {
-		return set(request, response, shouldClearFlash(request, response) ? clearCookie() : flashCookie());
-	}
+    private Response setFlashCookie(Request request, Response response) {
+        return set(request, response, shouldClearFlash(request, response) ? clearCookie() : flashCookie());
+    }
 
-	private Response set(final Request request, final Response response, final Cookie cookie) {
-		if (cookieAlreadyHasSameValue(request, cookie)  || (isEmptyJson(cookie.value()) && !cookies(request).contains(FLASH_COOKIE))) {
-			return response;
-		}
-		return modify(response).cookie(cookie).build();
-	}
+    private Response set(final Request request, final Response response, final Cookie cookie) {
+        if (cookieAlreadyHasSameValue(request, cookie) || (isEmptyJson(cookie.value()) && !cookies(request).contains(FLASH_COOKIE))) {
+            return response;
+        }
+        return modify(response).cookie(cookie).build();
+    }
 
-	private boolean shouldClearFlash(Request request, Response response) {
-		return clearFlashPredicate.matches(pair(request, response));
-	}
+    private boolean shouldClearFlash(Request request, Response response) {
+        return clearFlashPredicate.matches(pair(request, response));
+    }
 
-	private boolean cookieAlreadyHasSameValue(final Request request, final Cookie cookie) {
-		return cookie.value().equals(cookies(request).getValue(FLASH_COOKIE));
-	}
+    private boolean cookieAlreadyHasSameValue(final Request request, final Cookie cookie) {
+        return cookie.value().equals(cookies(request).getValue(FLASH_COOKIE));
+    }
 
-	private static boolean isEmptyJson(final String value) {
-		return EMPTY_FLASH_COOKIE_JSON.equals(value);
-	}
+    private static boolean isEmptyJson(final String value) {
+        return EMPTY_FLASH_COOKIE_JSON.equals(value);
+    }
 
-	private Cookie clearCookie() {
-		return flashCookie(EMPTY_FLASH_COOKIE_JSON);
-	}
+    private Cookie clearCookie() {
+        return flashCookie(EMPTY_FLASH_COOKIE_JSON);
+    }
 
-	private Cookie flashCookie() {
-		return flashCookie(toJson(flash.state()));
-	}
+    private Cookie flashCookie() {
+        return flashCookie(toJson(flash.state()));
+    }
 
-	private Cookie flashCookie(String json) {
-        return new Cookie(FLASH_COOKIE, json, path(basePath.toString()));
+    private Cookie flashCookie(String json) {
+        return new Cookie(FLASH_COOKIE, json, cookieAttributes());
+    }
+
+    private CookieAttribute[] cookieAttributes() {
+        final Sequence<CookieAttribute> attributes = sequence(flashCookieAttributes);
+        return attributes.toArray(new CookieAttribute[attributes.size()]);
     }
 }

--- a/src/com/googlecode/utterlyidle/flash/FlashMessagesModule.java
+++ b/src/com/googlecode/utterlyidle/flash/FlashMessagesModule.java
@@ -9,6 +9,7 @@ public class FlashMessagesModule implements RequestScopedModule {
 	public Container addPerRequestObjects(Container container) throws Exception {
 		return container.
 				add(ClearFlashPredicate.class, ClearFlashOnSuccessfulNonInternalHtmlResponse.class).
+				add(FlashCookieAttributes.class).
 				add(Flash.class).
 				decorate(HttpHandler.class, FlashHandler.class);
 	}

--- a/test/com/googlecode/utterlyidle/flash/FlashHandlerTest.java
+++ b/test/com/googlecode/utterlyidle/flash/FlashHandlerTest.java
@@ -1,6 +1,9 @@
 package com.googlecode.utterlyidle.flash;
 
+import com.googlecode.totallylazy.Option;
+import com.googlecode.totallylazy.Predicate;
 import com.googlecode.utterlyidle.Application;
+import com.googlecode.utterlyidle.BasePath;
 import com.googlecode.utterlyidle.Redirector;
 import com.googlecode.utterlyidle.RequestBuilder;
 import com.googlecode.utterlyidle.Resources;
@@ -12,11 +15,17 @@ import com.googlecode.utterlyidle.annotations.GET;
 import com.googlecode.utterlyidle.annotations.POST;
 import com.googlecode.utterlyidle.annotations.Path;
 import com.googlecode.utterlyidle.annotations.Produces;
+import com.googlecode.utterlyidle.cookies.Cookie;
+import com.googlecode.utterlyidle.cookies.CookieAttribute;
+import com.googlecode.utterlyidle.cookies.CookieCutter;
+import com.googlecode.utterlyidle.modules.RequestScopedModule;
 import com.googlecode.utterlyidle.modules.ResourcesModule;
+import com.googlecode.yadic.Container;
 import org.junit.Test;
 
 import static com.googlecode.funclate.Model.persistent.model;
 import static com.googlecode.funclate.json.Json.toJson;
+import static com.googlecode.totallylazy.Sequences.sequence;
 import static com.googlecode.totallylazy.matchers.Matchers.is;
 import static com.googlecode.totallylazy.proxy.Call.method;
 import static com.googlecode.totallylazy.proxy.Call.on;
@@ -29,91 +38,136 @@ import static com.googlecode.utterlyidle.RequestBuilder.post;
 import static com.googlecode.utterlyidle.ResponseBuilder.response;
 import static com.googlecode.utterlyidle.Status.OK;
 import static com.googlecode.utterlyidle.annotations.AnnotatedBindings.annotatedClass;
+import static com.googlecode.utterlyidle.cookies.CookieAttribute.httpOnly;
+import static com.googlecode.utterlyidle.cookies.CookieAttribute.path;
 import static com.googlecode.utterlyidle.cookies.CookieParameters.cookies;
+import static com.googlecode.utterlyidle.flash.FlashCookieAttributes.flashCookieAttributes;
 import static com.googlecode.utterlyidle.flash.FlashHandler.FLASH_COOKIE;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
 
 public class FlashHandlerTest {
-	private static final String CLEARED_FLASH_COOKIE_VALUE = "{}";
-	private final Application application = new RestApplication(basePath("/")).
-			add(new FlashMessagesModule()).
-			add(new ResourcesModule() {
-				@Override
-				public Resources addResources(Resources resources) throws Exception {
-					return resources.add(annotatedClass(FlashResource.class));
-				}
-			});
+    private static final String CLEARED_FLASH_COOKIE_VALUE = "{}";
+    private final Application application = new RestApplication(basePath("/")).
+            add(new FlashMessagesModule()).
+            add(new ResourcesModule() {
+                @Override
+                public Resources addResources(Resources resources) throws Exception {
+                    return resources.add(annotatedClass(FlashResource.class));
+                }
+            });
 
-	@Test
-	public void shouldReturnFlashStateInCookie() throws Exception {
-		Response redirectResponse = application.handle(post("/add").form("value", "Hello world").build());
+    @Test
+    public void shouldReturnFlashStateInCookie() throws Exception {
+        Response redirectResponse = application.handle(post("/add").form("value", "Hello world").build());
 
-		String redirectResponseCookie = flashCookie(redirectResponse);
-		assertThat(
-				"Should set flash cookies on non-2xx response",
+        String redirectResponseCookie = flashCookie(redirectResponse);
+        assertThat(
+                "Should set flash cookies on non-2xx response",
                 redirectResponseCookie,
-				is(toJson(model().set("key", "Hello world"))));
+                is(toJson(model().set("key", "Hello world"))));
 
-		Response responseFromRedirectLocation = followRedirect(redirectResponse);
+        Response responseFromRedirectLocation = followRedirect(redirectResponse);
 
-		String responseFromRedirectLocationCookie = flashCookie(responseFromRedirectLocation);
+        String responseFromRedirectLocationCookie = flashCookie(responseFromRedirectLocation);
 
-		assertThat(
-				"Flash value should be taken from the last cookie sent",
-				responseFromRedirectLocation.entity().toString(),
-				is("Hello world"));
+        assertThat(
+                "Flash value should be taken from the last cookie sent",
+                responseFromRedirectLocation.entity().toString(),
+                is("Hello world"));
 
-		assertThat(
-				"Flash cookie should be removed on successful response so it only displays once",
+        assertThat(
+                "Flash cookie should be removed on successful response so it only displays once",
                 responseFromRedirectLocationCookie,
-				is("{}"));
-	}
+                is("{}"));
+    }
 
-	@Test
-	public void shouldAppendValuesToFlashUntilASuccessfulResponseIsReturned() throws Exception {
-		Response firstError = application.handle(post("/addAndError").
-				form("value", "Error 1").build());
-		String firstErrorFlashCookie = flashCookie(firstError);
+    @Test
+    public void shouldAppendValuesToFlashUntilASuccessfulResponseIsReturned() throws Exception {
+        Response firstError = application.handle(post("/addAndError").
+                form("value", "Error 1").build());
+        String firstErrorFlashCookie = flashCookie(firstError);
 
-		Response secondError = application.handle(withFlashCookie(firstErrorFlashCookie, post("/addAndError").
-				form("value", "Error 2")).build());
+        Response secondError = application.handle(withFlashCookie(firstErrorFlashCookie, post("/addAndError").
+                form("value", "Error 2")).build());
 
-		String secondErrorFlashCookie = flashCookie(secondError);
+        String secondErrorFlashCookie = flashCookie(secondError);
 
-		assertThat(
-				"Should append flash cookies on non-2xx response",
+        assertThat(
+                "Should append flash cookies on non-2xx response",
                 secondErrorFlashCookie,
-				is(toJson(model().
-						add("key", "Error 1").
-						add("key", "Error 2"))));
-	}
+                is(toJson(model().
+                        add("key", "Error 1").
+                        add("key", "Error 2"))));
+    }
 
-	@Test
-	public void onlySetCookieIfValueChanges() throws Exception {
-		Response response = application.handle(withFlashCookie(CLEARED_FLASH_COOKIE_VALUE, get("/hi")).build());
-		assertThat(response.status(), is(OK));
-		assertThat(cookies(response).contains(FLASH_COOKIE), is(false));
-	}
+    @Test
+    public void onlySetCookieIfValueChanges() throws Exception {
+        Response response = application.handle(withFlashCookie(CLEARED_FLASH_COOKIE_VALUE, get("/hi")).build());
+        assertThat(response.status(), is(OK));
+        assertThat(cookies(response).contains(FLASH_COOKIE), is(false));
+    }
 
-	@Test
-	public void thereIsNoNeedToSetTheFlashCookieIfItsValueIsEmptyJsonAndTheIncomingRequestHasNoFlashCookie () throws Exception {
-		Response response = application.handle(get("/hi").build());
-		assertThat(response.status(), is(OK));
-		assertThat(cookies(response).contains(FLASH_COOKIE), is(false));
-	}
+    @Test
+    public void thereIsNoNeedToSetTheFlashCookieIfItsValueIsEmptyJsonAndTheIncomingRequestHasNoFlashCookie() throws Exception {
+        Response response = application.handle(get("/hi").build());
+        assertThat(response.status(), is(OK));
+        assertThat(cookies(response).contains(FLASH_COOKIE), is(false));
+    }
 
-	@Test
-	public void migratesPreviousEmptyCookieValueToNewEmptyCookieValue () throws Exception {
-		Response response = application.handle(withFlashCookie("", get("/hi")).build());
-		assertThat(response.status(), is(OK));
-		assertThat(cookies(response).getValue(FLASH_COOKIE), is(CLEARED_FLASH_COOKIE_VALUE));
-	}
+    @Test
+    public void migratesPreviousEmptyCookieValueToNewEmptyCookieValue() throws Exception {
+        Response response = application.handle(withFlashCookie("", get("/hi")).build());
+        assertThat(response.status(), is(OK));
+        assertThat(cookies(response).getValue(FLASH_COOKIE), is(CLEARED_FLASH_COOKIE_VALUE));
+    }
 
-	private Response followRedirect(Response response) throws Exception {
-		String flash = flashCookie(response);
-		String redirectLocation = response.headers().getValue(LOCATION);
-		return application.handle(withFlashCookie(flash, get(redirectLocation)).build());
-	}
+    @Test
+    public void shouldAddOnlyPathAttributeByDefault() throws Exception {
+        Response redirectResponse = application.handle(post("/add").form("value", "Hello world").build());
+
+        Option<Cookie> flashCookie = sequence(CookieCutter.cookies(redirectResponse)).find(cookieNamed(FLASH_COOKIE));
+        assertThat(
+                "Should set path attribute on flash cookie",
+                flashCookie.get().attributes(),
+                contains(path("/")));
+    }
+
+    @Test
+    public void shouldAddAllRequiredAttributesWhenFlashCookieAttributesIsOverridden() throws Exception {
+        Application modifiedApplication = application.
+                add(new RequestScopedModule() {
+                    @Override
+                    public Container addPerRequestObjects(final Container container) throws Exception {
+                        container.remove(FlashCookieAttributes.class);
+                        return container.addInstance(FlashCookieAttributes.class, flashCookieAttributes(container.get(BasePath.class), CookieAttribute.httpOnly()));
+                    }
+                });
+
+        Response redirectResponse = modifiedApplication.handle(post("/add").form("value", "Hello world").build());
+
+        Option<Cookie> flashCookie = sequence(CookieCutter.cookies(redirectResponse)).find(cookieNamed(FLASH_COOKIE));
+        assertThat(
+                "Should set path attribute on flash cookie",
+                flashCookie.get().attributes(),
+                containsInAnyOrder(path("/"), httpOnly()));
+    }
+
+    private Predicate<Cookie> cookieNamed(final String name) {
+        return new Predicate<Cookie>() {
+            @Override
+            public boolean matches(final Cookie other) {
+                return name.equals(other.name());
+            }
+        };
+    }
+
+    private Response followRedirect(Response response) throws Exception {
+        String flash = flashCookie(response);
+        String redirectLocation = response.headers().getValue(LOCATION);
+        return application.handle(withFlashCookie(flash, get(redirectLocation)).build());
+    }
 
     private String flashCookie(Response response) {
         return cookies(response).getValue(FLASH_COOKIE);
@@ -121,44 +175,44 @@ public class FlashHandlerTest {
 
 
     private RequestBuilder withFlashCookie(String flash, RequestBuilder request) {
-		return request.cookie(FLASH_COOKIE, flash);
-	}
+        return request.cookie(FLASH_COOKIE, flash);
+    }
 
-	public static class FlashResource {
-		private final Redirector redirector;
-		private final Flash flash;
+    public static class FlashResource {
+        private final Redirector redirector;
+        private final Flash flash;
 
-		public FlashResource(Redirector redirector, Flash flash) {
-			this.redirector = redirector;
-			this.flash = flash;
-		}
+        public FlashResource(Redirector redirector, Flash flash) {
+            this.redirector = redirector;
+            this.flash = flash;
+        }
 
-		@GET
+        @GET
         @Produces(TEXT_PLAIN)
-		@Path("hi")
-		public String hello(){
-			return "hello";
-		}
+        @Path("hi")
+        public String hello() {
+            return "hello";
+        }
 
-		@GET
+        @GET
         @Produces(APPLICATION_XHTML_XML)
-		@Path("get")
-		public Object get(){
-			return flash.state().get("key");
-		}
+        @Path("get")
+        public Object get() {
+            return flash.state().get("key");
+        }
 
-		@POST
-		@Path("add")
-		public Response set(@FormParam("value") String value){
-			this.flash.add("key", value);
-			return redirector.seeOther(method(on(FlashResource.class).get()));
-		}
+        @POST
+        @Path("add")
+        public Response set(@FormParam("value") String value) {
+            this.flash.add("key", value);
+            return redirector.seeOther(method(on(FlashResource.class).get()));
+        }
 
-		@POST
-		@Path("addAndError")
-		public Response error(@FormParam("value") String value){
-			this.flash.add("key", value);
-			return response(Status.INTERNAL_SERVER_ERROR).build();
-		}
-	}
+        @POST
+        @Path("addAndError")
+        public Response error(@FormParam("value") String value) {
+            this.flash.add("key", value);
+            return response(Status.INTERNAL_SERVER_ERROR).build();
+        }
+    }
 }


### PR DESCRIPTION
We'd like to lock down the Flash cookie to HttpOnly. So we've pulled the existing attribute (path) out to a new class; this can then be overridden to customise the attributes if needed.

Also, default IDEA really, really dislikes tabs in files ;-)