### PR TITLE
Removed Java 8 specific iterator methods

### DIFF
--- a/src/com/googlecode/utterlyidle/flash/FlashCookieAttributes.java
+++ b/src/com/googlecode/utterlyidle/flash/FlashCookieAttributes.java
@@ -5,8 +5,6 @@ import com.googlecode.utterlyidle.BasePath;
 import com.googlecode.utterlyidle.cookies.CookieAttribute;
 
 import java.util.Iterator;
-import java.util.Spliterator;
-import java.util.function.Consumer;
 
 import static com.googlecode.totallylazy.Sequences.sequence;
 import static com.googlecode.utterlyidle.cookies.CookieAttribute.path;
@@ -33,13 +31,4 @@ public class FlashCookieAttributes implements Iterable<CookieAttribute> {
         return cookieAttributes.iterator();
     }
 
-    @Override
-    public void forEach(final Consumer<? super CookieAttribute> action) {
-        cookieAttributes.forEach(action);
-    }
-
-    @Override
-    public Spliterator<CookieAttribute> spliterator() {
-        return cookieAttributes.spliterator();
-    }
 }


### PR DESCRIPTION
This should fix the build failure in the java7 branch, as I'm a tit and built the previous pull request against Java 8. Apologies.