### PR TITLE
Prevent malformed flash cookie from breaking requests

### DIFF
--- a/src/com/googlecode/utterlyidle/flash/FlashHandler.java
+++ b/src/com/googlecode/utterlyidle/flash/FlashHandler.java
@@ -9,6 +9,9 @@ import com.googlecode.utterlyidle.cookies.Cookie;
 import com.googlecode.utterlyidle.cookies.CookieAttribute;
 import com.googlecode.utterlyidle.cookies.CookieParameters;
 
+import java.util.Map;
+
+import static com.googlecode.totallylazy.Maps.map;
 import static com.googlecode.totallylazy.Pair.pair;
 import static com.googlecode.totallylazy.Sequences.sequence;
 import static com.googlecode.totallylazy.Strings.isBlank;
@@ -54,7 +57,15 @@ public class FlashHandler implements HttpHandler {
         if (!requestCookies.contains(FLASH_COOKIE) || isEmptyJson(requestCookies.getValue(FLASH_COOKIE)) || isBlank(requestCookies.getValue(FLASH_COOKIE)))
             return;
 
-        flash.merge(Json.parseMap(requestCookies.getValue(FLASH_COOKIE)).value());
+        flash.merge(safelyParse(requestCookies.getValue(FLASH_COOKIE)));
+    }
+
+    private static Map<String, Object> safelyParse(final String value) {
+        try {
+            return Json.parseMap(value).value();
+        } catch (RuntimeException ignored) {
+        }
+        return map();
     }
 
     private Response setFlashCookie(Request request, Response response) {

--- a/test/com/googlecode/utterlyidle/flash/FlashHandlerTest.java
+++ b/test/com/googlecode/utterlyidle/flash/FlashHandlerTest.java
@@ -38,6 +38,7 @@ import static com.googlecode.utterlyidle.Request.Builder.form;
 import static com.googlecode.utterlyidle.Request.get;
 import static com.googlecode.utterlyidle.Request.post;
 import static com.googlecode.utterlyidle.Response.response;
+import static com.googlecode.utterlyidle.Status.NO_CONTENT;
 import static com.googlecode.utterlyidle.Status.OK;
 import static com.googlecode.utterlyidle.annotations.AnnotatedBindings.annotatedClass;
 import static com.googlecode.utterlyidle.cookies.CookieAttribute.httpOnly;
@@ -93,6 +94,13 @@ public class FlashHandlerTest {
                 "Should append flash cookies on non-2xx response",
                 secondErrorFlashCookie,
                 is(Json.json(Maps.map("key", list("Error 1", "Error 2")))));
+    }
+
+    @Test
+    public void handlesCorruptedJsonCookie() throws Exception {
+        Response response = application.handle(Request.get("/get", cookie(FLASH_COOKIE, "invalid cookie")));
+
+        assertThat(response.status(), is(NO_CONTENT));
     }
 
     @Test


### PR DESCRIPTION
Currently, a GET request containing a cookie with malformed json will cause the whole request to fail. This patch should prevent this from happening by just ignoring the cookie.