### PR TITLE
Prevent malformed flash cookie from breaking requests

### DIFF
--- a/src/com/googlecode/utterlyidle/flash/FlashHandler.java
+++ b/src/com/googlecode/utterlyidle/flash/FlashHandler.java
@@ -57,7 +57,15 @@ public class FlashHandler implements HttpHandler {
         if (!requestCookies.contains(FLASH_COOKIE) || isEmptyJson(requestCookies.getValue(FLASH_COOKIE)) || isBlank(requestCookies.getValue(FLASH_COOKIE)))
             return;
 
-        flash.merge(Model.persistent.parse(requestCookies.getValue(FLASH_COOKIE)));
+        flash.merge(safelyParse(requestCookies.getValue(FLASH_COOKIE)));
+    }
+
+    private static Model safelyParse(final String value) {
+        try {
+            return Model.persistent.parse(value);
+        } catch (Exception ignore) {
+        }
+        return Model.persistent.model();
     }
 
     private Response setFlashCookie(Request request, Response response) {

--- a/test/com/googlecode/utterlyidle/flash/FlashHandlerTest.java
+++ b/test/com/googlecode/utterlyidle/flash/FlashHandlerTest.java
@@ -5,6 +5,7 @@ import com.googlecode.totallylazy.Predicate;
 import com.googlecode.utterlyidle.Application;
 import com.googlecode.utterlyidle.BasePath;
 import com.googlecode.utterlyidle.Redirector;
+import com.googlecode.utterlyidle.Request;
 import com.googlecode.utterlyidle.RequestBuilder;
 import com.googlecode.utterlyidle.Resources;
 import com.googlecode.utterlyidle.Response;
@@ -36,6 +37,7 @@ import static com.googlecode.utterlyidle.MediaType.TEXT_PLAIN;
 import static com.googlecode.utterlyidle.RequestBuilder.get;
 import static com.googlecode.utterlyidle.RequestBuilder.post;
 import static com.googlecode.utterlyidle.ResponseBuilder.response;
+import static com.googlecode.utterlyidle.Status.NO_CONTENT;
 import static com.googlecode.utterlyidle.Status.OK;
 import static com.googlecode.utterlyidle.annotations.AnnotatedBindings.annotatedClass;
 import static com.googlecode.utterlyidle.cookies.CookieAttribute.httpOnly;
@@ -100,6 +102,13 @@ public class FlashHandlerTest {
                 is(toJson(model().
                         add("key", "Error 1").
                         add("key", "Error 2"))));
+    }
+
+    @Test
+    public void handlesCorruptedJsonCookie() throws Exception {
+        Response response = application.handle(get("/get").cookie(FLASH_COOKIE, "invalid cookie").build());
+
+        assertThat(response.status(), is(NO_CONTENT));
     }
 
     @Test


### PR DESCRIPTION
Currently, a GET request containing a cookie with malformed json will cause the whole request to fail. This patch should prevent this from happening by just ignoring the cookie.