### PR TITLE
Add support for AWS Signature Version 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ lib/runtime
 lib/optional
 .idea/dictionaries/*
 test/**/s3.properties
+test/**/aws.properties
 *~

--- a/src/com/googlecode/utterlyidle/aws/AwsCanonicalRequest.java
+++ b/src/com/googlecode/utterlyidle/aws/AwsCanonicalRequest.java
@@ -1,0 +1,70 @@
+package com.googlecode.utterlyidle.aws;
+
+import com.googlecode.utterlyidle.QueryParameters;
+import com.googlecode.utterlyidle.Request;
+
+import java.util.Comparator;
+
+import static com.googlecode.totallylazy.Pair.pair;
+import static com.googlecode.totallylazy.Sequences.sequence;
+import static com.googlecode.totallylazy.UrlEncodedMessage.encode;
+
+public class AwsCanonicalRequest {
+    private final String canonical;
+    private final String signedHeaders;
+    private final String payloadHash;
+
+    public AwsCanonicalRequest(Request request) {
+        signedHeaders = signedHeaders(request);
+        payloadHash = payloadHash(request);
+        canonical = request.method() +
+            "\n" +
+            request.uri().path() +
+            "\n" +
+            canonicalQueryString(request) +
+            "\n" +
+            canonicalHeaders(request) +
+            "\n\n" +
+            signedHeaders +
+            "\n" +
+            payloadHash;
+    }
+
+    private String signedHeaders(Request request) {
+        return sequence(request.headers())
+            .map(header -> header.first().toLowerCase())
+            .sortBy(Comparator.naturalOrder())
+            .toString(";");
+    }
+
+    private String canonicalHeaders(Request request) {
+        return sequence(request.headers())
+            .map(header -> pair(header.first().toLowerCase(), header.second().replaceAll("\\s+", " ").trim()))
+            .map(header -> header.first() + ":" + header.second())
+            .sortBy(Comparator.naturalOrder())
+            .toString("\n");
+    }
+
+    private String canonicalQueryString(Request request) {
+        QueryParameters parameters = QueryParameters.parse(request.uri().query());
+        return sequence(parameters).map(param -> encode(param.getKey()) + "=" + encode(param.getValue()))
+            .sortBy(Comparator.naturalOrder())
+            .toString("&");
+    }
+
+    private String payloadHash(Request request) {
+        return AwsHmacSha256.hash(request.entity().asBytes());
+    }
+
+    public String signedHeaders() {
+        return signedHeaders;
+    }
+
+    public String payloadHash() {
+        return payloadHash;
+    }
+
+    public String toString() {
+        return canonical;
+    }
+}

--- a/src/com/googlecode/utterlyidle/aws/AwsCredentialScope.java
+++ b/src/com/googlecode/utterlyidle/aws/AwsCredentialScope.java
@@ -1,0 +1,33 @@
+package com.googlecode.utterlyidle.aws;
+
+
+import static java.lang.String.format;
+
+public class AwsCredentialScope {
+    private final String service;
+    private final String region;
+
+    private AwsCredentialScope(String region, String service) {
+        this.service = service;
+        this.region = region;
+    }
+
+    public static AwsCredentialScope awsCredentialScope(String region, String service) {
+        return new AwsCredentialScope(region, service);
+    }
+
+    public String service() {
+        return service;
+    }
+
+    public String region() {
+        return region;
+    }
+
+    public String awsCredentialScope(AwsRequestDate date) {
+        return format("%s/%s/%s/aws4_request",
+                date.basic(),
+                region,
+                service);
+    }
+}

--- a/src/com/googlecode/utterlyidle/aws/AwsHmacSha256.java
+++ b/src/com/googlecode/utterlyidle/aws/AwsHmacSha256.java
@@ -1,0 +1,42 @@
+package com.googlecode.utterlyidle.aws;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class AwsHmacSha256 {
+
+    public static String hash(String payload) {
+        return hash(payload.getBytes());
+    }
+
+    public static String hash(byte[] payload) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] res = digest.digest(payload);
+            return hex(res);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static byte[] hmacSHA256(byte[] key, String data) {
+        try {
+            String algorithm = "HmacSHA256";
+            Mac mac = Mac.getInstance(algorithm);
+            mac.init(new SecretKeySpec(key, algorithm));
+            return mac.doFinal(data.getBytes("UTF8"));
+        } catch (Exception e) {
+            throw new RuntimeException("Could not run HMAC SHA256", e);
+        }
+    }
+
+    public static String hex(byte[] data) {
+        StringBuilder result = new StringBuilder();
+        for (byte aByte : data) {
+            result.append(String.format("%02x", aByte));
+        }
+        return result.toString().toLowerCase();
+    }
+}

--- a/src/com/googlecode/utterlyidle/aws/AwsHttpClient.java
+++ b/src/com/googlecode/utterlyidle/aws/AwsHttpClient.java
@@ -1,0 +1,61 @@
+package com.googlecode.utterlyidle.aws;
+
+import com.googlecode.totallylazy.time.Clock;
+import com.googlecode.totallylazy.time.SystemClock;
+import com.googlecode.utterlyidle.HttpMessage;
+import com.googlecode.utterlyidle.Request;
+import com.googlecode.utterlyidle.Response;
+import com.googlecode.utterlyidle.handlers.AuditHandler;
+import com.googlecode.utterlyidle.handlers.HttpClient;
+import com.googlecode.utterlyidle.s3.AwsCredentials;
+
+import static com.googlecode.totallylazy.functions.Functions.modify;
+
+public class AwsHttpClient implements HttpClient {
+
+    private final HttpClient handler;
+    private final Clock clock;
+    private final AwsCredentialScope scope;
+    private final AwsCredentials credentials;
+
+    public AwsHttpClient(HttpClient client, Clock clock, AwsCredentialScope scope, AwsCredentials credentials) {
+        this.handler = client;
+        this.clock = clock;
+        this.scope = scope;
+        this.credentials = credentials;
+    }
+
+    public AwsHttpClient(final AuditHandler auditHandler, final AwsCredentialScope scope, final AwsCredentials credentials) {
+        this(auditHandler, new SystemClock(), scope, credentials);
+    }
+
+    public Response handle(Request request) throws Exception {
+        AwsRequestDate date = AwsRequestDate.awsRequestDate(clock.now());
+
+        Request fullRequest = modify(request,
+                HttpMessage.Builder.header("host", request.uri().host()),
+                HttpMessage.Builder.header("x-amz-date", date.full())
+        );
+
+        AwsCanonicalRequest canonicalRequest = new AwsCanonicalRequest(fullRequest);
+
+        Request signedRequest = modify(fullRequest,
+                HttpMessage.Builder.header("Authorization", buildAuthHeader(canonicalRequest, date)),
+                HttpMessage.Builder.header("x-amz-content-sha256", canonicalRequest.payloadHash())
+        );
+
+        return handler.handle(signedRequest);
+    }
+
+    private String buildAuthHeader(AwsCanonicalRequest canonicalRequest, AwsRequestDate date) {
+        AwsSignatureV4Signer signer = new AwsSignatureV4Signer();
+
+        String signature = signer.sign(canonicalRequest, scope, credentials, date);
+
+        return String.format("%s Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+                AwsStringToSign.ALGORITHM,
+                credentials.accessKeyId(), scope.awsCredentialScope(date),
+                canonicalRequest.signedHeaders(),
+                signature);
+    }
+}

--- a/src/com/googlecode/utterlyidle/aws/AwsRequestDate.java
+++ b/src/com/googlecode/utterlyidle/aws/AwsRequestDate.java
@@ -1,0 +1,25 @@
+package com.googlecode.utterlyidle.aws;
+
+import com.googlecode.totallylazy.time.Dates;
+
+import java.util.Date;
+
+public class AwsRequestDate {
+    private final Date date;
+
+    private AwsRequestDate(Date date) {
+        this.date = date;
+    }
+
+    public static AwsRequestDate awsRequestDate(Date date) {
+        return new AwsRequestDate(date);
+    }
+
+    public String basic() {
+        return Dates.format("yyyyMMdd").format(date);
+    }
+
+    public String full() {
+        return Dates.format("yyyyMMdd'T'HHmmss'Z'").format(date);
+    }
+}

--- a/src/com/googlecode/utterlyidle/aws/AwsSignatureV4Signer.java
+++ b/src/com/googlecode/utterlyidle/aws/AwsSignatureV4Signer.java
@@ -1,0 +1,32 @@
+package com.googlecode.utterlyidle.aws;
+
+import com.googlecode.utterlyidle.s3.AwsCredentials;
+
+import java.io.UnsupportedEncodingException;
+
+import static com.googlecode.utterlyidle.aws.AwsHmacSha256.hex;
+import static com.googlecode.utterlyidle.aws.AwsHmacSha256.hmacSHA256;
+
+public class AwsSignatureV4Signer {
+
+    public String sign(AwsCanonicalRequest request, AwsCredentialScope scope, AwsCredentials awsCredentials, AwsRequestDate date) {
+        AwsStringToSign awsStringToSign = new AwsStringToSign(request, scope, date);
+        byte[] signatureKey = getSignatureKey(awsCredentials.secretKey(), date.basic(), scope.region(), scope.service());
+        byte[] signature = hmacSHA256(signatureKey, awsStringToSign.toString());
+        return hex(signature);
+    }
+
+    private byte[] getSignatureKey(String key, String dateStamp, String regionName, String serviceName) {
+        try {
+            byte[] kSecret = ("AWS4" + key).getBytes("UTF8");
+            byte[] kDate = hmacSHA256(kSecret, dateStamp);
+            byte[] kRegion = hmacSHA256(kDate, regionName);
+            byte[] kService = hmacSHA256(kRegion, serviceName);
+            return hmacSHA256(kService, "aws4_request");
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("Could not generate signature key", e);
+        }
+
+    }
+
+}

--- a/src/com/googlecode/utterlyidle/aws/AwsStringToSign.java
+++ b/src/com/googlecode/utterlyidle/aws/AwsStringToSign.java
@@ -1,0 +1,26 @@
+package com.googlecode.utterlyidle.aws;
+
+import static com.googlecode.utterlyidle.aws.AwsHmacSha256.hash;
+
+public class AwsStringToSign {
+
+    public static final String ALGORITHM = "AWS4-HMAC-SHA256";
+
+    private String stringToSign;
+
+    public AwsStringToSign(AwsCanonicalRequest canonicalRequest, AwsCredentialScope requestScope, AwsRequestDate date) {
+        this.stringToSign = ALGORITHM +
+            "\n" +
+            date.full() +
+            "\n" +
+            requestScope.awsCredentialScope(date) +
+            "\n" +
+            hash(canonicalRequest.toString());
+    }
+
+    @Override
+    public String toString() {
+        return stringToSign;
+    }
+
+}

--- a/test/com/googlecode/utterlyidle/aws/AwsCanonicalRequestTest.java
+++ b/test/com/googlecode/utterlyidle/aws/AwsCanonicalRequestTest.java
@@ -1,0 +1,50 @@
+package com.googlecode.utterlyidle.aws;
+
+import com.googlecode.utterlyidle.Request;
+import org.junit.Test;
+
+import static com.googlecode.utterlyidle.RequestBuilder.get;
+import static com.googlecode.utterlyidle.RequestBuilder.put;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class AwsCanonicalRequestTest {
+
+    @Test
+    public void transform_minimal_request() {
+        final Request build = get("/test").build();
+
+        AwsCanonicalRequest canonical = new AwsCanonicalRequest(build);
+
+        assertThat(canonical.toString(), is("GET\n" +
+                "/test\n" +
+                "\n" +
+                "content-length:0\n\n" +
+                "content-length\n" +
+                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
+    }
+
+    @Test
+    public void transform_full_request() {
+        final Request build = put("/put-path")
+                .query("z-param", "z value")
+                .query("a param", "a value")
+                .query("S param", "s value")
+                .header("z-header", "  a   value  ")
+                .header("a-header", "  another value  ")
+                .entity("hello world")
+                .build();
+
+        AwsCanonicalRequest canonical = new AwsCanonicalRequest(build);
+
+        assertThat(canonical.toString(), is("PUT\n" +
+                "/put-path\n" +
+                "S+param=s+value&a+param=a+value&z-param=z+value\n" +
+                "a-header:another value\n" +
+                "content-length:11\n" +
+                "z-header:a value\n" +
+                "\n" +
+                "a-header;content-length;z-header\n" +
+                "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"));
+    }
+}

--- a/test/com/googlecode/utterlyidle/aws/AwsHmacSha256Test.java
+++ b/test/com/googlecode/utterlyidle/aws/AwsHmacSha256Test.java
@@ -1,0 +1,27 @@
+package com.googlecode.utterlyidle.aws;
+
+import org.junit.Test;
+
+import static com.googlecode.totallylazy.matchers.Matchers.is;
+import static com.googlecode.utterlyidle.aws.AwsHmacSha256.hash;
+import static com.googlecode.utterlyidle.aws.AwsHmacSha256.hex;
+import static com.googlecode.utterlyidle.aws.AwsHmacSha256.hmacSHA256;
+import static org.junit.Assert.assertThat;
+
+public class AwsHmacSha256Test {
+
+    @Test
+    public void hash_content() {
+        assertThat(hash("test string"), is("d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b"));
+    }
+
+    @Test
+    public void hex_content() {
+        assertThat(hex("test string".getBytes()), is("7465737420737472696e67"));
+    }
+
+    @Test
+    public void encrypt_content() {
+        assertThat(hex(hmacSHA256("test key".getBytes(), "test string")), is("6864a9fdc9bc77190c4bc6d1d875a0afe19461907f486f4ba5213a1f15b71cc9"));
+    }
+}

--- a/test/com/googlecode/utterlyidle/aws/AwsHttpClientTest.java
+++ b/test/com/googlecode/utterlyidle/aws/AwsHttpClientTest.java
@@ -1,0 +1,62 @@
+package com.googlecode.utterlyidle.aws;
+
+import com.googlecode.totallylazy.time.Dates;
+import com.googlecode.totallylazy.time.SettableClock;
+import com.googlecode.utterlyidle.AuditTest;
+import com.googlecode.utterlyidle.Request;
+import com.googlecode.utterlyidle.handlers.AuditHandler;
+import com.googlecode.utterlyidle.s3.AwsCredentials;
+import com.googlecode.utterlyidle.s3.EmptyResponseHandler;
+import org.junit.Test;
+
+import static com.googlecode.totallylazy.Option.some;
+import static com.googlecode.utterlyidle.RequestBuilder.get;
+import static com.googlecode.utterlyidle.aws.AwsCredentialScope.awsCredentialScope;
+import static com.googlecode.utterlyidle.s3.AwsCredentials.awsCredentials;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class AwsHttpClientTest {
+
+    private final AuditTest.TestAuditor auditor = new AuditTest.TestAuditor();
+    private final AuditHandler auditHandler = new AuditHandler(new EmptyResponseHandler(), auditor);
+
+    private final AwsCredentialScope scope = awsCredentialScope("us-east", "s3");
+    private final AwsCredentials credentials = awsCredentials("access", "secret");
+
+    private final SettableClock clock = new SettableClock(Dates.date(2016, 1, 27, 15, 32, 50, 27));
+    private final AwsHttpClient client = new AwsHttpClient(auditHandler, clock, scope, credentials);
+
+    @Test
+    public void adds_authorization() throws Exception {
+        assertThat(
+                delegatedRequest(get("/test").build()).header("Authorization"),
+                is(some("AWS4-HMAC-SHA256 Credential=access/20160127/us-east/s3/aws4_request, SignedHeaders=content-length;x-amz-date, Signature=cfb15309d8787bd6879c2c01f805c2d6d648b3fd0719fe43647a6831fbce2774"))
+        );
+    }
+
+    @Test
+    public void adds_time_header() throws Exception {
+        assertThat(
+                delegatedRequest(get("/test").build()).header("x-amz-date"),
+                is(some("20160127T153250Z"))
+        );
+    }
+
+    @Test
+    public void adds_content_sha256() throws Exception {
+        assertThat(
+                delegatedRequest(get("/test").build()).header("x-amz-content-sha256"),
+                is(some("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
+        );
+    }
+
+    private Request delegatedRequest(final Request request) throws Exception {
+        return delegatedRequest(client, request);
+    }
+
+    private Request delegatedRequest(final AwsHttpClient client1, final Request request) throws Exception {
+        client1.handle(request);
+        return AuditTest.TestAuditor.receivedRequest;
+    }
+}

--- a/test/com/googlecode/utterlyidle/aws/AwsRealTest.java
+++ b/test/com/googlecode/utterlyidle/aws/AwsRealTest.java
@@ -1,0 +1,123 @@
+package com.googlecode.utterlyidle.aws;
+
+import com.googlecode.totallylazy.io.Uri;
+import com.googlecode.utterlyidle.Request;
+import com.googlecode.utterlyidle.handlers.AuditHandler;
+import com.googlecode.utterlyidle.handlers.ClientHttpHandler;
+import com.googlecode.utterlyidle.handlers.FullRequestPrintAuditor;
+import com.googlecode.utterlyidle.s3.S3;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import java.util.UUID;
+
+import static com.googlecode.totallylazy.matchers.Matchers.is;
+import static com.googlecode.utterlyidle.HttpMessage.Builder.entity;
+import static com.googlecode.utterlyidle.Status.NO_CONTENT;
+import static com.googlecode.utterlyidle.Status.OK;
+import static com.googlecode.utterlyidle.aws.AwsCredentialScope.awsCredentialScope;
+import static com.googlecode.utterlyidle.s3.AwsCredentials.awsCredentials;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assume.assumeTrue;
+
+public class AwsRealTest {
+    private AwsHttpClient client;
+    private String bucketName;
+    private String key;
+    private Uri bucketUrl;
+    private Uri keyUrl;
+    private Uri s3Root;
+
+    @BeforeClass
+    public static void checkPropertiesExist() {
+        assumeTrue(properties() != null);
+    }
+
+    @Before
+    public void createClient() throws IOException {
+        final Properties properties = new Properties();
+        properties.load(properties());
+
+        assertThat(
+                "Developer should understand what this test does- set signMyLifeAway property to the expected value.",
+                properties.getProperty("signMyLifeAway"),
+                is("I've checked the code of this test and understand that it creates and deletes buckets and keys using my credentials"));
+
+        client = new AwsHttpClient(
+                new AuditHandler(new ClientHttpHandler(), new FullRequestPrintAuditor()),
+                awsCredentialScope(properties.getProperty("region"), properties.getProperty("service")),
+                awsCredentials(properties.getProperty("accessKey"), properties.getProperty("secretKey")));
+
+        bucketName = UUID.randomUUID().toString();
+        key = UUID.randomUUID().toString();
+        bucketUrl = S3.toHttpUri(S3.uri(bucketName));
+        keyUrl = S3.toHttpUri(S3.uri(bucketName, key));
+        s3Root = S3.toHttpUri(S3.rootUri());
+    }
+
+    @Test
+    public void putThenGetThenDelete() throws Exception {
+        String contents = UUID.randomUUID().toString();
+
+        assertThat(
+                "Bucket should not exist in root listing",
+                client.handle(Request.get(s3Root)).entity().toString(),
+                not(containsString(bucketName)));
+        assertThat(
+                "Put of bucket should succeed",
+                client.handle(Request.put(bucketUrl)).status(),
+                is(OK));
+        assertThat(
+                "Bucket should exist in root listing",
+                client.handle(Request.get(s3Root)).entity().toString(),
+                containsString(bucketName));
+        assertThat(
+                "Key should not exist in bucket listing",
+                client.handle(Request.get(bucketUrl)).entity().toString(),
+                not(containsString(key)));
+        assertThat(
+                "Put of key should succeed",
+                client.handle(Request.put(keyUrl, entity(contents))).status(),
+                is(OK));
+        assertThat(
+                "Key should appear in bucket listing",
+                client.handle(Request.get(bucketUrl)).entity().toString(),
+                containsString(key));
+        assertThat(
+                "Key contents should be as expected",
+                client.handle(Request.get(keyUrl)).entity().toString(),
+                is(contents));
+        assertThat(
+                "Delete of key should succeed",
+                client.handle(Request.delete(keyUrl)).status(),
+                is(NO_CONTENT));
+        assertThat(
+                "Key should no longer appear in bucket listing",
+                client.handle(Request.get(bucketUrl)).entity().toString(),
+                not(containsString(key)));
+        assertThat(
+                "Delete of bucket should succeed",
+                client.handle(Request.delete(bucketUrl)).status(),
+                is(NO_CONTENT));
+        assertThat(
+                "Bucket should no longer exist in root listing",
+                client.handle(Request.get(s3Root)).entity().toString(),
+                not(containsString(bucketName)));
+    }
+
+    private static InputStream properties() {
+        return AwsRealTest.class.getResourceAsStream("aws.properties");
+    }
+
+    @After
+    public void removeBucket() throws Exception {
+        client.handle(Request.delete(bucketUrl));
+    }
+}

--- a/test/com/googlecode/utterlyidle/aws/AwsRequestDateTest.java
+++ b/test/com/googlecode/utterlyidle/aws/AwsRequestDateTest.java
@@ -1,0 +1,22 @@
+package com.googlecode.utterlyidle.aws;
+
+import com.googlecode.totallylazy.time.Dates;
+import org.junit.Test;
+
+import static com.googlecode.totallylazy.matchers.Matchers.is;
+import static com.googlecode.utterlyidle.aws.AwsRequestDate.awsRequestDate;
+import static org.junit.Assert.assertThat;
+
+public class AwsRequestDateTest {
+
+    @Test
+    public void basic_representation() {
+        assertThat(awsRequestDate(Dates.date(2016, 12, 25, 7, 35, 49)).basic(), is("20161225"));
+    }
+
+    @Test
+    public void full_representation() {
+        assertThat(awsRequestDate(Dates.date(2016, 12, 25, 7, 35, 49, 123)).full(), is("20161225T073549Z"));
+    }
+
+}

--- a/test/com/googlecode/utterlyidle/aws/AwsStringToSignTest.java
+++ b/test/com/googlecode/utterlyidle/aws/AwsStringToSignTest.java
@@ -1,0 +1,26 @@
+package com.googlecode.utterlyidle.aws;
+
+import org.junit.Test;
+
+import static com.googlecode.totallylazy.matchers.Matchers.is;
+import static com.googlecode.totallylazy.time.Dates.date;
+import static com.googlecode.utterlyidle.RequestBuilder.get;
+import static com.googlecode.utterlyidle.aws.AwsCredentialScope.awsCredentialScope;
+import static com.googlecode.utterlyidle.aws.AwsRequestDate.awsRequestDate;
+import static org.junit.Assert.assertThat;
+
+public class AwsStringToSignTest {
+
+    @Test
+    public void create_from_request() {
+        AwsCanonicalRequest request = new AwsCanonicalRequest(get("/test").build());
+        AwsRequestDate date = awsRequestDate(date(2016, 1, 27, 15, 32, 50, 27));
+
+        AwsStringToSign stringToSign = new AwsStringToSign(request, awsCredentialScope("us-east", "s3"), date);
+
+        assertThat(stringToSign.toString(), is("AWS4-HMAC-SHA256\n" +
+                "20160127T153250Z\n" +
+                "20160127/us-east/s3/aws4_request\n" +
+                AwsHmacSha256.hash(request.toString())));
+    }
+}


### PR DESCRIPTION
The existing implementation of S3HttpClient uses an [old signing mechanism](http://docs.aws.amazon.com/general/latest/gr/signature-version-2.html) which doesn't work on all AWS regions (eu-central-1, for instance).

For that reason I've introduced a AwsHttpClient which implements the latest [AWS Signature Version 4](http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html). It solves the region issue and allows authenticated requests to a [wide range of AWS services](http://docs.aws.amazon.com/general/latest/gr/sigv4_support.html). 