### PR TITLE
Define charset as UTF-8 for Base64 en/decoding

### DIFF
--- a/src/com/googlecode/utterlyidle/cookies/Base64Encoding.java
+++ b/src/com/googlecode/utterlyidle/cookies/Base64Encoding.java
@@ -2,17 +2,19 @@ package com.googlecode.utterlyidle.cookies;
 
 import com.googlecode.totallylazy.security.Base64;
 
+import java.nio.charset.StandardCharsets;
+
 public class Base64Encoding implements CookieEncoding {
 
     Base64Encoding() { }
 
     @Override
     public String encode(String input) {
-        return Base64.encode(input.getBytes());
+        return Base64.encode(input.getBytes(StandardCharsets.UTF_8));
     }
 
     @Override
     public String decode(String input) {
-        return new String(Base64.decode(input));
+        return new String(Base64.decode(input), StandardCharsets.UTF_8);
     }
 }


### PR DESCRIPTION
This fixes #37. Not specifying the charset uses the platform's default; goodness knows what Windows chose.

I'm not completely sure whether UTF-8 or UTF-16 is the right choice. Either would work, but it seems many editors (including IntelliJ) use UTF-8 by default.