### PR TITLE
Updated to Yadic 1.19, in particular for static initialiser ordering fix

### DIFF
--- a/build/runtime.dependencies
+++ b/build/runtime.dependencies
@@ -3,4 +3,4 @@ mvn:cglib:cglib-nodep:jar:2.2
 mvn:org.objenesis:objenesis:jar:1.2
 
 mvn://repo.bodar.com/com.googlecode.totallylazy:totallylazy:pack|sources:1.85
-mvn://repo.bodar.com/com.googlecode.yadic:yadic:pack|sources:1.5
+mvn://repo.bodar.com/com.googlecode.yadic:yadic:pack|sources:1.19


### PR DESCRIPTION
Updated to latest Yadic 1.x, in order to fix the unstable sort on static initialiser methods when matching binding parameters.