### PR TITLE
Fixed Flash.error/message to return single error/message arguments.

### DIFF
--- a/src/com/googlecode/utterlyidle/flash/Flash.java
+++ b/src/com/googlecode/utterlyidle/flash/Flash.java
@@ -79,11 +79,11 @@ public class Flash {
     }
 
     public Flash error(String value) {
-        return add(ERRORS, value);
+        return add(ERRORS, values.containsKey(ERRORS) ? value : list(value));
     }
 
     public Flash message(String value) {
-        return add(MESSAGES, value);
+        return add(MESSAGES, values.containsKey(MESSAGES) ? value : list(value));
     }
 
     public List<String> removeErrors(){

--- a/test/com/googlecode/utterlyidle/flash/FlashTest.java
+++ b/test/com/googlecode/utterlyidle/flash/FlashTest.java
@@ -17,6 +17,14 @@ public class FlashTest {
     }
 
     @Test
+    public void supportsASingleError() {
+        Flash flash = new Flash();
+        flash.error("Only error");
+
+        assertThat(flash.errors(), hasExactly("Only error"));
+    }
+
+    @Test
     public void supportsMessagesAsAListOfStrings() {
         Flash flash = new Flash().
                 message("First message").
@@ -24,5 +32,12 @@ public class FlashTest {
                 message("Third message");
 
         assertThat(flash.messages(), hasExactly("First message", "Second message", "Third message"));
+    }
+
+    @Test
+    public void supportsASingleMessage() {
+        Flash flash = new Flash();
+        flash.message("Only message");
+        assertThat(flash.messages(), hasExactly("Only message"));
     }
 }


### PR DESCRIPTION
Previous single error/message values would be stored directly in values and would only be converted to a list on the addition of a second value. The accessor would hence only return a list after the addition of two errors or messages.