### PR TITLE
Fix typo in SubDomainWildcardVerifier class name

### DIFF
--- a/src/com/googlecode/utterlyidle/handlers/SubDomainWildcardVerifier.java
+++ b/src/com/googlecode/utterlyidle/handlers/SubDomainWildcardVerifier.java
@@ -7,7 +7,7 @@ import javax.net.ssl.SSLSession;
 
 import static com.googlecode.totallylazy.Sequences.sequence;
 
-public class SubDomainWildardVerifier implements HostnameVerifier {
+public class SubDomainWildcardVerifier implements HostnameVerifier {
     public static final String CommonName = "CN";
 
     @Override


### PR DESCRIPTION
This PR fixes the name of the SubDomainWildcardVerifier class.